### PR TITLE
Refactor bundle migration related logic

### DIFF
--- a/library/src/main/java/com/cube/storm/ContentSettings.java
+++ b/library/src/main/java/com/cube/storm/ContentSettings.java
@@ -1,15 +1,17 @@
 package com.cube.storm;
 
 import android.content.Context;
+import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import android.text.TextUtils;
 import com.cube.storm.content.lib.Environment;
 import com.cube.storm.content.lib.factory.FileFactory;
 import com.cube.storm.content.lib.listener.DownloadListener;
 import com.cube.storm.content.lib.listener.UpdateListener;
 import com.cube.storm.content.lib.manager.APIManager;
+import com.cube.storm.content.lib.manager.DefaultMigrationManager;
 import com.cube.storm.content.lib.manager.DefaultUpdateManager;
+import com.cube.storm.content.lib.manager.MigrationManager;
 import com.cube.storm.content.lib.manager.UpdateManager;
 import com.cube.storm.content.lib.parser.BundleBuilder;
 import com.cube.storm.content.lib.resolver.CacheResolver;
@@ -94,6 +96,11 @@ public class ContentSettings
 	 * Default {@link com.cube.storm.content.lib.manager.UpdateManager} to use throughout the module
 	 */
 	@Getter @Setter private UpdateManager updateManager;
+
+	/**
+	 * Default {@link com.cube.storm.content.lib.manager.MigrationManager} to use throughout the module
+	 */
+	@Getter @Setter private MigrationManager migrationManager;
 
 	/**
 	 * The path to the storage folder on disk
@@ -191,6 +198,7 @@ public class ContentSettings
 
 			APIManager(new APIManager(){});
 			updateManager(new DefaultUpdateManager());
+			migrationManager(new DefaultMigrationManager());
 
 			fileFactory(new FileFactory(){});
 			bundleBuilder(new BundleBuilder(){});
@@ -366,6 +374,19 @@ public class ContentSettings
 		public Builder APIManager(@NonNull APIManager manager)
 		{
 			construct.apiManager = manager;
+			return this;
+		}
+
+		/**
+		 * Set the default migration manager
+		 *
+		 * @param manager The new Migration manager
+		 *
+		 * @return The {@link com.cube.storm.ContentSettings.Builder} instance for chaining
+		 */
+		public Builder migrationManager(@NonNull MigrationManager manager)
+		{
+			construct.migrationManager = manager;
 			return this;
 		}
 

--- a/library/src/main/java/com/cube/storm/content/lib/helper/BundleHelper.java
+++ b/library/src/main/java/com/cube/storm/content/lib/helper/BundleHelper.java
@@ -1,8 +1,16 @@
 package com.cube.storm.content.lib.helper;
 
 import android.net.Uri;
+import android.util.Log;
 import com.cube.storm.ContentSettings;
+import com.cube.storm.content.lib.Constants;
 import com.cube.storm.content.model.Manifest;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.io.File;
 
 public class BundleHelper
 {
@@ -18,6 +26,49 @@ public class BundleHelper
 		FileHelper.deleteRecursive(new File(path, "languages/"));
 		FileHelper.deleteRecursive(new File(path, "app.json"));
 		FileHelper.deleteRecursive(new File(path, "manifest.json"));
+	}
+
+	/**
+	 * Checks the integrity of each file currently stored in cache
+	 * <p/>
+	 * This method compares the file hash with the hash in the manifest. If the hashes do not match, the bundle is discarded.
+	 *
+	 * @return true if the bundle has the correct integrity, false if it was discarded
+	 */
+	public static boolean integrityCheck(String contentPath)
+	{
+		boolean correct = true;
+
+		JsonObject manifest = new JsonParser().parse(ContentSettings.getInstance().getFileManager().readFileAsString(new File(contentPath, Constants.FILE_MANIFEST))).getAsJsonObject();
+
+		String[] sections = {"pages", "data", "content", "languages"};
+		String[] folders = {Constants.FOLDER_PAGES, Constants.FOLDER_DATA, Constants.FOLDER_CONTENT, Constants.FOLDER_LANGUAGES};
+
+		for (int index = 0; index < sections.length; index++)
+		{
+			JsonArray pages = manifest.get(sections[index]).getAsJsonArray();
+			for (JsonElement p : pages)
+			{
+				JsonObject page = p.getAsJsonObject();
+				String filename = page.get("src").getAsString();
+				String requiredHash = page.get("hash").getAsString();
+				String actualHash = ContentSettings.getInstance().getFileManager().getFileHash(contentPath + "/" + folders[index] + "/" + filename);
+
+				if (actualHash != null && !requiredHash.equals(actualHash))
+				{
+					correct = false;
+					Log.w("LightningContent", String.format("File %s has the wrong hash! Expected %s but got %s", filename, requiredHash, actualHash));
+					break;
+				}
+			}
+		}
+
+		if (!correct)
+		{
+			FileHelper.deleteRecursive(new File(contentPath));
+		}
+
+		return correct;
 	}
 
 	public static Long readContentTimestamp()

--- a/library/src/main/java/com/cube/storm/content/lib/helper/BundleHelper.java
+++ b/library/src/main/java/com/cube/storm/content/lib/helper/BundleHelper.java
@@ -6,9 +6,36 @@ import com.cube.storm.content.model.Manifest;
 
 public class BundleHelper
 {
+	/**
+	 * Deletes all files in {@link ContentSettings#getStoragePath()}
+	 */
+	public static void clearCache()
+	{
+		String path = ContentSettings.getInstance().getStoragePath();
+		FileHelper.deleteRecursive(new File(path, "pages/"));
+		FileHelper.deleteRecursive(new File(path, "data/"));
+		FileHelper.deleteRecursive(new File(path, "content/"));
+		FileHelper.deleteRecursive(new File(path, "languages/"));
+		FileHelper.deleteRecursive(new File(path, "app.json"));
+		FileHelper.deleteRecursive(new File(path, "manifest.json"));
+	}
+
 	public static Long readContentTimestamp()
 	{
 		Uri manifestUri = Uri.parse("cache://manifest.json");
+		Manifest manifest = ContentSettings.getInstance().getBundleBuilder().buildManifest(manifestUri);
+
+		if (manifest == null)
+		{
+			return null;
+		}
+
+		return manifest.getTimestamp();
+	}
+
+	public static Long readInitialTimestamp()
+	{
+		Uri manifestUri = Uri.parse("assets://manifest.json");
 		Manifest manifest = ContentSettings.getInstance().getBundleBuilder().buildManifest(manifestUri);
 
 		if (manifest == null)

--- a/library/src/main/java/com/cube/storm/content/lib/helper/FileHelper.java
+++ b/library/src/main/java/com/cube/storm/content/lib/helper/FileHelper.java
@@ -1,0 +1,102 @@
+package com.cube.storm.content.lib.helper;
+
+import android.text.TextUtils;
+import com.cube.storm.content.lib.Constants;
+import com.cube.storm.util.lib.debug.Debug;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Helper class for deleting files
+ *
+ * @author Callum Taylor
+ */
+public class FileHelper
+{
+	public static void copyDirectory(File sourceLocation, File targetLocation) throws IOException
+	{
+		if (sourceLocation.isDirectory())
+		{
+			if (!targetLocation.exists())
+			{
+				targetLocation.mkdir();
+			}
+
+			String[] children = sourceLocation.list();
+
+			for (String aChildren : children)
+			{
+				copyDirectory(new File(sourceLocation, aChildren), new File(targetLocation, aChildren));
+			}
+		}
+		else
+		{
+			int buffer = 8192;
+
+			InputStream in = new BufferedInputStream(new FileInputStream(sourceLocation), buffer);
+			OutputStream out = new BufferedOutputStream(new FileOutputStream(targetLocation), buffer);
+
+			byte[] buf = new byte[buffer];
+			int len;
+
+			while ((len = in.read(buf)) > 0)
+			{
+				out.write(buf, 0, len);
+			}
+
+			in.close();
+			out.flush();
+			out.close();
+		}
+	}
+
+	public static void deleteRecursive(File fileOrDirectory)
+	{
+		if (fileOrDirectory.isDirectory())
+		{
+			File[] files = fileOrDirectory.listFiles();
+
+			if (files != null)
+			{
+				for (File child : files)
+				{
+					deleteRecursive(child);
+				}
+			}
+		}
+
+		fileOrDirectory.delete();
+	}
+
+	/**
+	 * Purges files in a folder that do not exist in the manifest
+	 *
+	 * @param folderPath The folder to check, can be either, {@link Constants#FOLDER_PAGES}, {@link Constants#FOLDER_LANGUAGES}, {@link Constants#FOLDER_CONTENT}, or {@link Constants#FOLDER_DATA}
+	 * @param fileList The list of files to delete
+	 */
+	public static void removeFiles(String folderPath, String[] fileList)
+	{
+		if (fileList != null)
+		{
+			for (String s : fileList)
+			{
+				if (!TextUtils.isEmpty(s))
+				{
+					boolean deleted = new File(folderPath, s).delete();
+
+					if (!deleted)
+					{
+						Debug.out("%s was not deleted successfully", s);
+					}
+				}
+			}
+		}
+	}
+}

--- a/library/src/main/java/com/cube/storm/content/lib/manager/DefaultMigrationManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/manager/DefaultMigrationManager.java
@@ -1,0 +1,21 @@
+package com.cube.storm.content.lib.manager;
+
+import com.cube.storm.content.lib.helper.BundleHelper;
+
+public class DefaultMigrationManager implements MigrationManager
+{
+	@Override
+	public boolean migrate()
+	{
+		Long initialTimestamp = BundleHelper.readInitialTimestamp();
+		Long latestTimestamp = BundleHelper.readContentTimestamp();
+
+		if (initialTimestamp != null && latestTimestamp != null && initialTimestamp > latestTimestamp)
+		{
+			BundleHelper.clearCache();
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/library/src/main/java/com/cube/storm/content/lib/manager/DefaultUpdateManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/manager/DefaultUpdateManager.java
@@ -1,16 +1,15 @@
 package com.cube.storm.content.lib.manager;
 
 import android.text.TextUtils;
-import android.util.Log;
 import com.cube.storm.ContentSettings;
 import com.cube.storm.content.lib.Constants;
 import com.cube.storm.content.lib.handler.GZIPTarCacheResponseHandler;
+import com.cube.storm.content.lib.helper.BundleHelper;
+import com.cube.storm.content.lib.helper.FileHelper;
 import com.cube.storm.content.model.UpdateContentProgress;
-import com.cube.storm.util.lib.debug.Debug;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.subjects.BehaviorSubject;
@@ -19,14 +18,8 @@ import io.reactivex.subjects.Subject;
 import net.callumtaylor.asynchttp.AsyncHttpClient;
 import net.callumtaylor.asynchttp.response.JsonResponseHandler;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -239,11 +232,11 @@ public class DefaultUpdateManager implements UpdateManager
 
 						File path = new File(ContentSettings.getInstance().getStoragePath());
 
-						if (integrityCheck(getFilePath()))
+						if (BundleHelper.integrityCheck(getFilePath()))
 						{
 							// Move files from /delta to ../
-							copyDirectory(new File(getFilePath()), new File(ContentSettings.getInstance().getStoragePath()));
-							deleteRecursive(new File(getFilePath()));
+							FileHelper.copyDirectory(new File(getFilePath()), new File(ContentSettings.getInstance().getStoragePath()));
+							FileHelper.deleteRecursive(new File(getFilePath()));
 
 							File manifest = new File(path, Constants.FILE_MANIFEST);
 							JsonObject manifestJson = ContentSettings.getInstance().getFileManager().readFileAsJson(manifest).getAsJsonObject();
@@ -276,7 +269,7 @@ public class DefaultUpdateManager implements UpdateManager
 										}
 									}
 
-									removeFiles(path + "/" + key + "/", expectedContent.get(key));
+									FileHelper.removeFiles(path + "/" + key + "/", expectedContent.get(key));
 								}
 							}
 						}
@@ -349,128 +342,5 @@ public class DefaultUpdateManager implements UpdateManager
 	public Observable<Observable<UpdateContentProgress>> updates()
 	{
 		return updates;
-	}
-
-	/**
-	 * Purges files in a folder that do not exist in the manifest
-	 *
-	 * @param folderPath The folder to check, can be either, {@link Constants#FOLDER_PAGES}, {@link Constants#FOLDER_LANGUAGES}, {@link Constants#FOLDER_CONTENT}, or {@link Constants#FOLDER_DATA}
-	 * @param fileList The list of files to delete
-	 */
-	public void removeFiles(String folderPath, String[] fileList)
-	{
-		if (fileList != null)
-		{
-			for (String s : fileList)
-			{
-				if (!TextUtils.isEmpty(s))
-				{
-					boolean deleted = new File(folderPath, s).delete();
-
-					if (!deleted)
-					{
-						Debug.out("%s was not deleted successfully", s);
-					}
-				}
-			}
-		}
-	}
-
-	/**
-	 * Checks the integrity of each file currently stored in cache
-	 * <p/>
-	 * This method compares the file hash with the hash in the manifest. If the hashes do not match, the bundle is discarded.
-	 *
-	 * @return true if the bundle has the correct integrity, false if it was discarded
-	 */
-	public boolean integrityCheck(String contentPath)
-	{
-		boolean correct = true;
-
-		JsonObject manifest = new JsonParser().parse(ContentSettings.getInstance().getFileManager().readFileAsString(new File(contentPath, Constants.FILE_MANIFEST))).getAsJsonObject();
-
-		String[] sections = {"pages", "data", "content", "languages"};
-		String[] folders = {Constants.FOLDER_PAGES, Constants.FOLDER_DATA, Constants.FOLDER_CONTENT, Constants.FOLDER_LANGUAGES};
-
-		for (int index = 0; index < sections.length; index++)
-		{
-			JsonArray pages = manifest.get(sections[index]).getAsJsonArray();
-			for (JsonElement p : pages)
-			{
-				JsonObject page = p.getAsJsonObject();
-				String filename = page.get("src").getAsString();
-				String requiredHash = page.get("hash").getAsString();
-				String actualHash = ContentSettings.getInstance().getFileManager().getFileHash(contentPath + "/" + folders[index] + "/" + filename);
-
-				if (actualHash != null && !requiredHash.equals(actualHash))
-				{
-					correct = false;
-					Log.w("LightningContent", String.format("File %s has the wrong hash! Expected %s but got %s", filename, requiredHash, actualHash));
-					break;
-				}
-			}
-		}
-
-		if (!correct)
-		{
-			deleteRecursive(new File(contentPath));
-		}
-
-		return correct;
-	}
-
-	private void deleteRecursive(File fileOrDirectory)
-	{
-		if (fileOrDirectory.isDirectory())
-		{
-			File[] files = fileOrDirectory.listFiles();
-
-			if (files != null)
-			{
-				for (File child : files)
-				{
-					deleteRecursive(child);
-				}
-			}
-		}
-
-		fileOrDirectory.delete();
-	}
-
-	private void copyDirectory(File sourceLocation, File targetLocation) throws IOException
-	{
-		if (sourceLocation.isDirectory())
-		{
-			if (!targetLocation.exists())
-			{
-				targetLocation.mkdir();
-			}
-
-			String[] children = sourceLocation.list();
-
-			for (String aChildren : children)
-			{
-				copyDirectory(new File(sourceLocation, aChildren), new File(targetLocation, aChildren));
-			}
-		}
-		else
-		{
-			int buffer = 8192;
-
-			InputStream in = new BufferedInputStream(new FileInputStream(sourceLocation), buffer);
-			OutputStream out = new BufferedOutputStream(new FileOutputStream(targetLocation), buffer);
-
-			byte[] buf = new byte[buffer];
-			int len;
-
-			while ((len = in.read(buf)) > 0)
-			{
-				out.write(buf, 0, len);
-			}
-
-			in.close();
-			out.flush();
-			out.close();
-		}
 	}
 }

--- a/library/src/main/java/com/cube/storm/content/lib/manager/MigrationManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/manager/MigrationManager.java
@@ -1,0 +1,6 @@
+package com.cube.storm.content.lib.manager;
+
+public interface MigrationManager
+{
+	boolean migrate();
+}


### PR DESCRIPTION
This PR adds logic relating to content migrations to the content library. Previously this logic was in the developer library, even though it is not strictly related to development - we always want to be able to perform content migrations