### PR TITLE
Refactor logic relating to wi-fi update policy

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <manifest
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	package="com.cube.storm.content"
-/>
+>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+</manifest>

--- a/library/src/main/java/com/cube/storm/ContentSettings.java
+++ b/library/src/main/java/com/cube/storm/ContentSettings.java
@@ -13,8 +13,10 @@ import com.cube.storm.content.lib.manager.DefaultMigrationManager;
 import com.cube.storm.content.lib.manager.DefaultUpdateManager;
 import com.cube.storm.content.lib.manager.MigrationManager;
 import com.cube.storm.content.lib.manager.UpdateManager;
-import com.cube.storm.content.lib.manager.WifiOnlyUpdateManager;
+import com.cube.storm.content.lib.policy.PolicyEnforcingUpdateManager;
 import com.cube.storm.content.lib.parser.BundleBuilder;
+import com.cube.storm.content.lib.policy.PolicyManager;
+import com.cube.storm.content.lib.policy.SharedPreferencesPolicyManager;
 import com.cube.storm.content.lib.resolver.CacheResolver;
 import com.cube.storm.util.lib.manager.FileManager;
 import com.cube.storm.util.lib.resolver.AssetsResolver;
@@ -102,6 +104,11 @@ public class ContentSettings
 	 * Default {@link com.cube.storm.content.lib.manager.MigrationManager} to use throughout the module
 	 */
 	@Getter @Setter private MigrationManager migrationManager;
+
+	/**
+	 * Default {@link com.cube.storm.content.lib.policy.PolicyManager} to use throughout the module
+	 */
+	@Getter @Setter private PolicyManager policyManager;
 
 	/**
 	 * The path to the storage folder on disk
@@ -199,7 +206,8 @@ public class ContentSettings
 
 			APIManager(new APIManager(){});
 			migrationManager(new DefaultMigrationManager());
-			updateManager(new WifiOnlyUpdateManager(this.context, new DefaultUpdateManager()));
+			policyManager(new SharedPreferencesPolicyManager(this.context));
+			updateManager(new PolicyEnforcingUpdateManager(new DefaultUpdateManager()));
 
 			fileFactory(new FileFactory(){});
 			bundleBuilder(new BundleBuilder(){});
@@ -388,6 +396,19 @@ public class ContentSettings
 		public Builder migrationManager(@NonNull MigrationManager manager)
 		{
 			construct.migrationManager = manager;
+			return this;
+		}
+
+		/**
+		 * Set the default policy manager
+		 *
+		 * @param manager The new policy manager
+		 *
+		 * @return The {@link com.cube.storm.ContentSettings.Builder} instance for chaining
+		 */
+		public Builder policyManager(@NonNull PolicyManager manager)
+		{
+			construct.policyManager = manager;
 			return this;
 		}
 

--- a/library/src/main/java/com/cube/storm/ContentSettings.java
+++ b/library/src/main/java/com/cube/storm/ContentSettings.java
@@ -13,6 +13,7 @@ import com.cube.storm.content.lib.manager.DefaultMigrationManager;
 import com.cube.storm.content.lib.manager.DefaultUpdateManager;
 import com.cube.storm.content.lib.manager.MigrationManager;
 import com.cube.storm.content.lib.manager.UpdateManager;
+import com.cube.storm.content.lib.manager.WifiOnlyUpdateManager;
 import com.cube.storm.content.lib.parser.BundleBuilder;
 import com.cube.storm.content.lib.resolver.CacheResolver;
 import com.cube.storm.util.lib.manager.FileManager;
@@ -197,8 +198,8 @@ public class ContentSettings
 			this.context = context.getApplicationContext();
 
 			APIManager(new APIManager(){});
-			updateManager(new DefaultUpdateManager());
 			migrationManager(new DefaultMigrationManager());
+			updateManager(new WifiOnlyUpdateManager(this.context, new DefaultUpdateManager()));
 
 			fileFactory(new FileFactory(){});
 			bundleBuilder(new BundleBuilder(){});

--- a/library/src/main/java/com/cube/storm/content/lib/helper/BundleHelper.java
+++ b/library/src/main/java/com/cube/storm/content/lib/helper/BundleHelper.java
@@ -9,6 +9,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import timber.log.Timber;
 
 import java.io.File;
 
@@ -19,6 +20,7 @@ public class BundleHelper
 	 */
 	public static void clearCache()
 	{
+		Timber.tag("storm_diagnostics").i("Clearing cached content");
 		String path = ContentSettings.getInstance().getStoragePath();
 		FileHelper.deleteRecursive(new File(path, "pages/"));
 		FileHelper.deleteRecursive(new File(path, "data/"));

--- a/library/src/main/java/com/cube/storm/content/lib/manager/WifiOnlyUpdateManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/manager/WifiOnlyUpdateManager.java
@@ -1,0 +1,93 @@
+package com.cube.storm.content.lib.manager;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import android.preference.PreferenceManager;
+import com.cube.storm.content.model.UpdateContentProgress;
+import io.reactivex.Observable;
+
+/**
+ * {@link UpdateManager} which ensures updates only occur on a wi-fi connection, otherwise delegating to another
+ * UpdateManager.
+ */
+public class WifiOnlyUpdateManager implements UpdateManager
+{
+	private ConnectivityManager connectivityManager;
+	private SharedPreferences preferences;
+	private UpdateManager delegate;
+
+	public WifiOnlyUpdateManager(Context context, UpdateManager delegate)
+	{
+		connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+		preferences = PreferenceManager.getDefaultSharedPreferences(context);
+		this.delegate = delegate;
+	}
+
+	@Override
+	public void cancelPendingRequests()
+	{
+		delegate.cancelPendingRequests();
+	}
+
+	@Override
+	public Observable<UpdateContentProgress> checkForBundle()
+	{
+		if (!canDownload())
+		{
+			return Observable.error(new IllegalStateException("Not connected to wifi"));
+		}
+		return delegate.checkForBundle();
+	}
+
+	@Override
+	public Observable<UpdateContentProgress> checkForUpdates(long lastUpdate)
+	{
+		if (!canDownload())
+		{
+			return Observable.error(new IllegalStateException("Not connected to wifi"));
+		}
+		return delegate.checkForUpdates(lastUpdate);
+	}
+
+	private boolean canDownload()
+	{
+		return preferences.getBoolean("wifi_only", false) && !isConnectedToWifi();
+	}
+
+	/**
+	 * Checks if the user is connected to wifi or not. Ensure you provide the {@link android.Manifest.permission#ACCESS_WIFI_STATE} permission in
+	 * your manifest.
+	 *
+	 * @return True if connected, or the check failed. False if not connected. May return true even if the user has no
+	 * active internet connection with their selected wifi service
+	 */
+	private boolean isConnectedToWifi()
+	{
+		try
+		{
+			NetworkInfo networkInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
+			return networkInfo.isConnected();
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace();
+		}
+
+		// Assume they are.
+		return true;
+	}
+
+	@Override
+	public void scheduleBackgroundUpdates()
+	{
+		delegate.scheduleBackgroundUpdates();
+	}
+
+	@Override
+	public Observable<Observable<UpdateContentProgress>> updates()
+	{
+		return delegate.updates();
+	}
+}

--- a/library/src/main/java/com/cube/storm/content/lib/manager/WifiOnlyUpdateManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/manager/WifiOnlyUpdateManager.java
@@ -53,7 +53,7 @@ public class WifiOnlyUpdateManager implements UpdateManager
 
 	private boolean canDownload()
 	{
-		return preferences.getBoolean("wifi_only", false) && !isConnectedToWifi();
+		return !preferences.getBoolean("wifi_only", false) || isConnectedToWifi();
 	}
 
 	/**

--- a/library/src/main/java/com/cube/storm/content/lib/policy/PolicyEnforcingUpdateManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/policy/PolicyEnforcingUpdateManager.java
@@ -1,11 +1,8 @@
-package com.cube.storm.content.lib.manager;
+package com.cube.storm.content.lib.policy;
 
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
-import android.preference.PreferenceManager;
 import androidx.annotation.NonNull;
+import com.cube.storm.ContentSettings;
+import com.cube.storm.content.lib.manager.UpdateManager;
 import com.cube.storm.content.lib.worker.ContentUpdateWorker;
 import com.cube.storm.content.model.UpdateContentRequest;
 import io.reactivex.Observable;
@@ -14,16 +11,12 @@ import io.reactivex.Observable;
  * {@link UpdateManager} which ensures updates only occur on a wi-fi connection, otherwise delegating to another
  * UpdateManager.
  */
-public class WifiOnlyUpdateManager implements UpdateManager
+public class PolicyEnforcingUpdateManager implements UpdateManager
 {
-	private ConnectivityManager connectivityManager;
-	private SharedPreferences preferences;
 	private UpdateManager delegate;
 
-	public WifiOnlyUpdateManager(Context context, UpdateManager delegate)
+	public PolicyEnforcingUpdateManager(UpdateManager delegate)
 	{
-		connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-		preferences = PreferenceManager.getDefaultSharedPreferences(context);
 		this.delegate = delegate;
 	}
 
@@ -36,7 +29,7 @@ public class WifiOnlyUpdateManager implements UpdateManager
 	@Override
 	public UpdateContentRequest checkForBundle()
 	{
-		if (!canDownload())
+		if (!ContentSettings.getInstance().getPolicyManager().canUpdate())
 		{
 			return new UpdateContentRequest(
 				Long.toString(System.currentTimeMillis()),
@@ -51,7 +44,7 @@ public class WifiOnlyUpdateManager implements UpdateManager
 	@Override
 	public UpdateContentRequest checkForUpdates(long lastUpdate)
 	{
-		if (!canDownload())
+		if (!ContentSettings.getInstance().getPolicyManager().canUpdate())
 		{
 			return new UpdateContentRequest(
 				Long.toString(System.currentTimeMillis()),
@@ -63,15 +56,10 @@ public class WifiOnlyUpdateManager implements UpdateManager
 		return delegate.checkForUpdates(lastUpdate);
 	}
 
-	private boolean canDownload()
-	{
-		return !preferences.getBoolean("wifi_only", false) || isConnectedToWifi();
-	}
-
 	@Override
 	public UpdateContentRequest downloadUpdates(@NonNull String endpoint)
 	{
-		if (!canDownload())
+		if (!ContentSettings.getInstance().getPolicyManager().canUpdate())
 		{
 			return new UpdateContentRequest(
 				Long.toString(System.currentTimeMillis()),
@@ -81,29 +69,6 @@ public class WifiOnlyUpdateManager implements UpdateManager
 			);
 		}
 		return delegate.downloadUpdates(endpoint);
-	}
-
-	/**
-	 * Checks if the user is connected to wifi or not. Ensure you provide the {@link android.Manifest.permission#ACCESS_WIFI_STATE} permission in
-	 * your manifest.
-	 *
-	 * @return True if connected, or the check failed. False if not connected. May return true even if the user has no
-	 * active internet connection with their selected wifi service
-	 */
-	private boolean isConnectedToWifi()
-	{
-		try
-		{
-			NetworkInfo networkInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
-			return networkInfo.isConnected();
-		}
-		catch (Exception e)
-		{
-			e.printStackTrace();
-		}
-
-		// Assume they are.
-		return true;
 	}
 
 	@Override

--- a/library/src/main/java/com/cube/storm/content/lib/policy/PolicyManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/policy/PolicyManager.java
@@ -1,0 +1,7 @@
+package com.cube.storm.content.lib.policy;
+
+public interface PolicyManager
+{
+	boolean canUpdate();
+	boolean isCellularDownloadPermitted();
+}

--- a/library/src/main/java/com/cube/storm/content/lib/policy/SharedPreferencesPolicyManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/policy/SharedPreferencesPolicyManager.java
@@ -1,0 +1,58 @@
+package com.cube.storm.content.lib.policy;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import android.preference.PreferenceManager;
+import androidx.annotation.NonNull;
+
+public class SharedPreferencesPolicyManager implements PolicyManager
+{
+	public static final String PREF_KEY_WIFI_ONLY = "wifi_only";
+
+	private ConnectivityManager connectivityManager;
+	private SharedPreferences preferences;
+
+	public SharedPreferencesPolicyManager(@NonNull Context context)
+	{
+		connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+		preferences = PreferenceManager.getDefaultSharedPreferences(context);
+	}
+
+	@Override
+	public boolean canUpdate()
+	{
+		return isConnectedToWifi() || isCellularDownloadPermitted();
+	}
+
+	@Override
+	public boolean isCellularDownloadPermitted()
+	{
+		return !preferences.getBoolean(PREF_KEY_WIFI_ONLY, false);
+	}
+
+	/**
+	 * Checks if the user is connected to wifi or not. Ensure you provide the {@link android.Manifest.permission#ACCESS_WIFI_STATE}
+	 * permission in your manifest.
+	 *
+	 * @return True if connected, or the check failed. False if not connected. May return true even if the user has no
+	 * active internet connection with their selected wifi service
+	 */
+	private boolean isConnectedToWifi()
+	{
+		try
+		{
+			NetworkInfo networkInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
+			return networkInfo.isConnected();
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace();
+		}
+
+		// Assume they are.
+		return true;
+	}
+
+}

--- a/library/src/main/java/com/cube/storm/content/lib/worker/BackgroundWorkerUpdateManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/worker/BackgroundWorkerUpdateManager.java
@@ -15,6 +15,7 @@ import androidx.work.OneTimeWorkRequest;
 import androidx.work.PeriodicWorkRequest;
 import androidx.work.WorkInfo;
 import androidx.work.WorkManager;
+import com.cube.storm.ContentSettings;
 import com.cube.storm.content.lib.manager.UpdateManager;
 import com.cube.storm.content.model.UpdateContentProgress;
 import com.cube.storm.content.model.UpdateContentRequest;
@@ -45,7 +46,10 @@ public class BackgroundWorkerUpdateManager implements UpdateManager
 	@NonNull
 	private static Constraints createWorkConstraints()
 	{
-		return new Constraints.Builder().setRequiredNetworkType(NetworkType.UNMETERED).build();
+		boolean canDownloadOnCellular = ContentSettings.getInstance().getPolicyManager().isCellularDownloadPermitted();
+		return new Constraints.Builder()
+			       .setRequiredNetworkType(canDownloadOnCellular ? NetworkType.CONNECTED : NetworkType.UNMETERED)
+			       .build();
 	}
 
 	/**

--- a/library/src/main/java/com/cube/storm/content/lib/worker/BackgroundWorkerUpdateManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/worker/BackgroundWorkerUpdateManager.java
@@ -88,7 +88,7 @@ public class BackgroundWorkerUpdateManager implements UpdateManager
 
 		Data inputData = inputDataBuilder.build();
 		return new OneTimeWorkRequest.Builder(ContentUpdateWorker.class)
-			       .setConstraints(CONTENT_CHECK_WORK_CONSTRAINTS)
+			       .setConstraints(createWorkConstraints())
 			       .setInputData(inputData)
 			       .build();
 	}
@@ -103,14 +103,13 @@ public class BackgroundWorkerUpdateManager implements UpdateManager
 			                            ContentUpdateWorker.UPDATE_MANAGER_IMPL_WORKER
 			                 ).putInt(ContentUpdateWorker.INPUT_KEY_UPDATE_TYPE, DELTA.ordinal()).build();
 		return new PeriodicWorkRequest.Builder(ContentUpdateWorker.class, 20L, MINUTES, 10L, MINUTES)
-			       .setConstraints(CONTENT_CHECK_WORK_CONSTRAINTS)
+			       .setConstraints(createWorkConstraints())
 			       .setInputData(inputData)
 			       .build();
 	}
 
 	private static final String CONTENT_CHECK_WORK_NAME = "storm_content_check";
 	private static final String CONTENT_CHECK_SCHEDULE_NAME = "storm_content_check_schedule";
-	private static final Constraints CONTENT_CHECK_WORK_CONSTRAINTS = createWorkConstraints();
 
 	private WorkManager workManager;
 


### PR DESCRIPTION
This PR refactors logic relating to wi-fi policy into the content library. Previously it was in the developer library even though it is not strictly related to development.

To support wi-fi policy I have added a new `WifiOnlyUpdateManager` that wraps any other `UpdateManager` implementation. This is now the default. The code in this file is all copied from the developer library. In future I'd like to refactor it further so the `wifi_only` preference is also decoupled from the developer library.

Functionality is the same as previously, this is just a refactor.