### PR TITLE
Add ability for bundle checks to obey landmark boundaries by providing the binary timestamp

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.1.0-SNAPSHOT
+VERSION_NAME=1.2.0-SNAPSHOT
 GROUP=com.3sidedcube.storm
 
 POM_NAME=LightningContent

--- a/library/src/main/java/com/cube/storm/content/lib/helper/BundleHelper.java
+++ b/library/src/main/java/com/cube/storm/content/lib/helper/BundleHelper.java
@@ -33,6 +33,11 @@ public class BundleHelper
 		FileHelper.deleteRecursive(new File(path, "manifest.json"));
 	}
 
+	public static boolean hasContent()
+	{
+		return readContentTimestamp() != null;
+	}
+
 	/**
 	 * Checks the integrity of each file currently stored in cache
 	 * <p/>

--- a/library/src/main/java/com/cube/storm/content/lib/manager/UpdateManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/manager/UpdateManager.java
@@ -1,6 +1,7 @@
 package com.cube.storm.content.lib.manager;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.cube.storm.content.lib.helper.BundleHelper;
 import com.cube.storm.content.model.UpdateContentRequest;
 import io.reactivex.Observable;
@@ -15,14 +16,14 @@ public interface UpdateManager
 	void cancelPendingRequests();
 
 	/**
-	 * Downloads the latest full bundle from the server.
+	 * Downloads the latest full bundle from the server that is valid for an app built at the specified buildTime.
 	 * <p>
-	 * Ignores the timestamp in the local manifest file, so the downloaded bundle may be incompatible with the binary
-	 * if for example a landmark publish has occurred
+	 * This method will respect landmark publishes, and won't download bundles incompatible with a binary. Send in null
+	 * to retrieve the latest bundle, irrespective of landmark publishes.
 	 * <p>
 	 * Despite the name this method will also download updates, not just check for them.
 	 */
-	UpdateContentRequest checkForBundle();
+	UpdateContentRequest checkForBundle(@Nullable Long buildTime);
 
 	/**
 	 * Checks for updates on the server and downloads any new files in the form of a delta bundle
@@ -31,13 +32,13 @@ public interface UpdateManager
 	 * <p>
 	 * Despite the name this method will also download updates, not just check for them.
 	 */
-	default UpdateContentRequest checkForUpdates()
+	default UpdateContentRequest checkForUpdatesToLocalContent(@Nullable Long buildTime)
 	{
 		Long bundleTimestamp = BundleHelper.readContentTimestamp();
 
 		if (bundleTimestamp == null)
 		{
-			return checkForBundle();
+			return checkForBundle(buildTime);
 		}
 		else
 		{

--- a/library/src/main/java/com/cube/storm/content/lib/manager/UpdateManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/manager/UpdateManager.java
@@ -32,13 +32,13 @@ public interface UpdateManager
 	 * <p>
 	 * Despite the name this method will also download updates, not just check for them.
 	 */
-	default UpdateContentRequest checkForUpdatesToLocalContent(@Nullable Long buildTime)
+	default UpdateContentRequest checkForUpdatesToLocalContent()
 	{
 		Long bundleTimestamp = BundleHelper.readContentTimestamp();
 
 		if (bundleTimestamp == null)
 		{
-			return checkForBundle(buildTime);
+			throw new IllegalStateException("No bundle to update");
 		}
 		else
 		{

--- a/library/src/main/java/com/cube/storm/content/lib/policy/PolicyEnforcingUpdateManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/policy/PolicyEnforcingUpdateManager.java
@@ -1,9 +1,9 @@
 package com.cube.storm.content.lib.policy;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.cube.storm.ContentSettings;
 import com.cube.storm.content.lib.manager.UpdateManager;
-import com.cube.storm.content.lib.worker.ContentUpdateWorker;
 import com.cube.storm.content.model.UpdateContentRequest;
 import io.reactivex.Observable;
 
@@ -27,18 +27,13 @@ public class PolicyEnforcingUpdateManager implements UpdateManager
 	}
 
 	@Override
-	public UpdateContentRequest checkForBundle()
+	public UpdateContentRequest checkForBundle(@Nullable Long buildTimestamp)
 	{
 		if (!ContentSettings.getInstance().getPolicyManager().canUpdate())
 		{
-			return new UpdateContentRequest(
-				Long.toString(System.currentTimeMillis()),
-				ContentUpdateWorker.UpdateType.FULL_BUNDLE,
-				null,
-				Observable.error(new IllegalStateException("Not connected to wifi"))
-			);
+			return UpdateContentRequest.fullBundle(buildTimestamp, Observable.error(new IllegalStateException("Not connected to wifi")));
 		}
-		return delegate.checkForBundle();
+		return delegate.checkForBundle(buildTimestamp);
 	}
 
 	@Override
@@ -46,12 +41,7 @@ public class PolicyEnforcingUpdateManager implements UpdateManager
 	{
 		if (!ContentSettings.getInstance().getPolicyManager().canUpdate())
 		{
-			return new UpdateContentRequest(
-				Long.toString(System.currentTimeMillis()),
-				ContentUpdateWorker.UpdateType.DELTA,
-				lastUpdate,
-				Observable.error(new IllegalStateException("Not connected to wifi"))
-			);
+			return UpdateContentRequest.deltaUpdate(lastUpdate, Observable.error(new IllegalStateException("Not connected to wifi")));
 		}
 		return delegate.checkForUpdates(lastUpdate);
 	}
@@ -61,12 +51,7 @@ public class PolicyEnforcingUpdateManager implements UpdateManager
 	{
 		if (!ContentSettings.getInstance().getPolicyManager().canUpdate())
 		{
-			return new UpdateContentRequest(
-				Long.toString(System.currentTimeMillis()),
-				ContentUpdateWorker.UpdateType.DIRECT_DOWNLOAD,
-				null,
-				Observable.error(new IllegalStateException("Not connected to wifi"))
-			);
+			return UpdateContentRequest.directDownload(Observable.error(new IllegalStateException("Not connected to wifi")));
 		}
 		return delegate.downloadUpdates(endpoint);
 	}

--- a/library/src/main/java/com/cube/storm/content/lib/worker/BackgroundWorkerUpdateManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/worker/BackgroundWorkerUpdateManager.java
@@ -141,13 +141,13 @@ public class BackgroundWorkerUpdateManager implements UpdateManager
 	}
 
 	@Override
-	public UpdateContentRequest checkForUpdatesToLocalContent(@Nullable Long buildTimestamp)
+	public UpdateContentRequest checkForUpdatesToLocalContent()
 	{
-		OneTimeWorkRequest workRequest = createOneTimeWorkRequest(DELTA, buildTimestamp, null, null);
+		OneTimeWorkRequest workRequest = createOneTimeWorkRequest(DELTA, null, null, null);
 		log(String.format("Enqueuing update check (%s)", workRequest.getId().toString()));
 		workManager.enqueueUniqueWork(CONTENT_CHECK_WORK_NAME, ExistingWorkPolicy.REPLACE, workRequest);
 		Observable<UpdateContentProgress> progressObservable = createWorkObservable(workRequest.getId());
-		UpdateContentRequest updateContentRequest = UpdateContentRequest.deltaUpdateFromLocalContent(buildTimestamp, progressObservable);
+		UpdateContentRequest updateContentRequest = UpdateContentRequest.deltaUpdateFromLocalContent(null, progressObservable);
 		updates.onNext(updateContentRequest);
 		return updateContentRequest;
 	}

--- a/library/src/main/java/com/cube/storm/content/lib/worker/BackgroundWorkerUpdateManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/worker/BackgroundWorkerUpdateManager.java
@@ -63,6 +63,7 @@ public class BackgroundWorkerUpdateManager implements UpdateManager
 	@NonNull
 	private static OneTimeWorkRequest createOneTimeWorkRequest(
 		@NonNull ContentUpdateWorker.UpdateType updateType,
+		@Nullable Long buildTimestamp,
 		@Nullable Long updateTimestamp,
 		@Nullable String updateEndpoint
 	)
@@ -74,16 +75,19 @@ public class BackgroundWorkerUpdateManager implements UpdateManager
 				                                ContentUpdateWorker.UPDATE_MANAGER_IMPL_DEFAULT
 			                                ).putInt(ContentUpdateWorker.INPUT_KEY_UPDATE_TYPE, updateType.ordinal());
 
+		if (buildTimestamp != null)
+		{
+			inputDataBuilder = inputDataBuilder.putLong(ContentUpdateWorker.INPUT_KEY_BUILD_TIMESTAMP, buildTimestamp);
+		}
+
 		if (updateTimestamp != null)
 		{
-			inputDataBuilder =
-				inputDataBuilder.putLong(ContentUpdateWorker.INPUT_KEY_UPDATE_TIMESTAMP, updateTimestamp);
+			inputDataBuilder = inputDataBuilder.putLong(ContentUpdateWorker.INPUT_KEY_UPDATE_TIMESTAMP, updateTimestamp);
 		}
 
 		if (updateEndpoint != null)
 		{
-			inputDataBuilder =
-				inputDataBuilder.putString(ContentUpdateWorker.INPUT_KEY_UPDATE_ENDPOINT, updateEndpoint);
+			inputDataBuilder = inputDataBuilder.putString(ContentUpdateWorker.INPUT_KEY_UPDATE_ENDPOINT, updateEndpoint);
 		}
 
 		Data inputData = inputDataBuilder.build();
@@ -125,33 +129,25 @@ public class BackgroundWorkerUpdateManager implements UpdateManager
 	}
 
 	@Override
-	public UpdateContentRequest checkForBundle()
+	public UpdateContentRequest checkForBundle(@Nullable Long buildTimestamp)
 	{
-		OneTimeWorkRequest workRequest = createOneTimeWorkRequest(FULL_BUNDLE, null, null);
+		OneTimeWorkRequest workRequest = createOneTimeWorkRequest(FULL_BUNDLE, buildTimestamp, null, null);
 		log(String.format("Enqueuing bundle check (%s)", workRequest.getId().toString()));
 		workManager.enqueueUniqueWork(CONTENT_CHECK_WORK_NAME, ExistingWorkPolicy.REPLACE, workRequest);
-		UpdateContentRequest updateContentRequest = new UpdateContentRequest(
-			workRequest.getId().toString(),
-			FULL_BUNDLE,
-			null,
-			createWorkObservable(workRequest.getId())
-		);
+		Observable<UpdateContentProgress> progressObservable = createWorkObservable(workRequest.getId());
+		UpdateContentRequest updateContentRequest = UpdateContentRequest.fullBundle(buildTimestamp, progressObservable);
 		updates.onNext(updateContentRequest);
 		return updateContentRequest;
 	}
 
 	@Override
-	public UpdateContentRequest checkForUpdates()
+	public UpdateContentRequest checkForUpdatesToLocalContent(@Nullable Long buildTimestamp)
 	{
-		OneTimeWorkRequest workRequest = createOneTimeWorkRequest(DELTA, null, null);
+		OneTimeWorkRequest workRequest = createOneTimeWorkRequest(DELTA, buildTimestamp, null, null);
 		log(String.format("Enqueuing update check (%s)", workRequest.getId().toString()));
 		workManager.enqueueUniqueWork(CONTENT_CHECK_WORK_NAME, ExistingWorkPolicy.REPLACE, workRequest);
-		UpdateContentRequest updateContentRequest = new UpdateContentRequest(
-			workRequest.getId().toString(),
-			DELTA,
-			null,
-			createWorkObservable(workRequest.getId())
-		);
+		Observable<UpdateContentProgress> progressObservable = createWorkObservable(workRequest.getId());
+		UpdateContentRequest updateContentRequest = UpdateContentRequest.deltaUpdateFromLocalContent(buildTimestamp, progressObservable);
 		updates.onNext(updateContentRequest);
 		return updateContentRequest;
 	}
@@ -159,15 +155,11 @@ public class BackgroundWorkerUpdateManager implements UpdateManager
 	@Override
 	public UpdateContentRequest checkForUpdates(long lastUpdate)
 	{
-		OneTimeWorkRequest workRequest = createOneTimeWorkRequest(DELTA, lastUpdate, null);
+		OneTimeWorkRequest workRequest = createOneTimeWorkRequest(DELTA, null, lastUpdate, null);
 		log(String.format("Enqueuing update check from %d (%s)", lastUpdate, workRequest.getId().toString()));
 		workManager.enqueueUniqueWork(CONTENT_CHECK_WORK_NAME, ExistingWorkPolicy.REPLACE, workRequest);
-		UpdateContentRequest updateContentRequest = new UpdateContentRequest(
-			workRequest.getId().toString(),
-			DELTA,
-			lastUpdate,
-			createWorkObservable(workRequest.getId())
-		);
+		Observable<UpdateContentProgress> progressObservable = createWorkObservable(workRequest.getId());
+		UpdateContentRequest updateContentRequest = UpdateContentRequest.deltaUpdate(lastUpdate, progressObservable);
 		updates.onNext(updateContentRequest);
 		return updateContentRequest;
 	}
@@ -185,15 +177,11 @@ public class BackgroundWorkerUpdateManager implements UpdateManager
 	@Override
 	public UpdateContentRequest downloadUpdates(@NonNull String endpoint)
 	{
-		OneTimeWorkRequest workRequest = createOneTimeWorkRequest(DIRECT_DOWNLOAD, null, endpoint);
+		OneTimeWorkRequest workRequest = createOneTimeWorkRequest(DIRECT_DOWNLOAD, null, null, endpoint);
 		log(String.format("Enqueuing download from %s (%s)", endpoint, workRequest.getId().toString()));
 		workManager.enqueueUniqueWork(CONTENT_CHECK_WORK_NAME, ExistingWorkPolicy.APPEND, workRequest);
-		UpdateContentRequest updateContentRequest = new UpdateContentRequest(
-			workRequest.getId().toString(),
-			DIRECT_DOWNLOAD,
-			null,
-			createWorkObservable(workRequest.getId())
-		);
+		Observable<UpdateContentProgress> progressObservable = createWorkObservable(workRequest.getId());
+		UpdateContentRequest updateContentRequest = UpdateContentRequest.directDownload(progressObservable);
 		updates.onNext(updateContentRequest);
 		return updateContentRequest;
 	}

--- a/library/src/main/java/com/cube/storm/content/lib/worker/BackgroundWorkerUpdateManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/worker/BackgroundWorkerUpdateManager.java
@@ -147,7 +147,7 @@ public class BackgroundWorkerUpdateManager implements UpdateManager
 		log(String.format("Enqueuing update check (%s)", workRequest.getId().toString()));
 		workManager.enqueueUniqueWork(CONTENT_CHECK_WORK_NAME, ExistingWorkPolicy.REPLACE, workRequest);
 		Observable<UpdateContentProgress> progressObservable = createWorkObservable(workRequest.getId());
-		UpdateContentRequest updateContentRequest = UpdateContentRequest.deltaUpdateFromLocalContent(null, progressObservable);
+		UpdateContentRequest updateContentRequest = UpdateContentRequest.deltaUpdateFromLocalContent(progressObservable);
 		updates.onNext(updateContentRequest);
 		return updateContentRequest;
 	}

--- a/library/src/main/java/com/cube/storm/content/lib/worker/ContentUpdateWorker.java
+++ b/library/src/main/java/com/cube/storm/content/lib/worker/ContentUpdateWorker.java
@@ -29,12 +29,13 @@ public class ContentUpdateWorker extends RxWorker
 	public static final String INPUT_KEY_UPDATE_MANAGER = "update_manager_impl";
 	public static final String INPUT_KEY_UPDATE_TYPE = "update_type";
 	public static final String INPUT_KEY_UPDATE_ENDPOINT = "update_endpoint";
+	public static final String INPUT_KEY_BUILD_TIMESTAMP = "build_timestamp";
 	public static final String INPUT_KEY_UPDATE_TIMESTAMP = "update_timestamp";
 
 	public static final String UPDATE_MANAGER_IMPL_DEFAULT = "update_manager_impl_default";
 	public static final String UPDATE_MANAGER_IMPL_WORKER = "update_manager_impl_worker";
 
-	private static final long UPDATE_TIMESTAMP_UNINITIALIZED = 0L;
+	private static final long TIMESTAMP_UNINITIALIZED = 0L;
 
 	public enum UpdateType
 	{
@@ -45,6 +46,7 @@ public class ContentUpdateWorker extends RxWorker
 
 	private UpdateManager updateManager;
 	private UpdateType updateType;
+	private long buildTimestamp;
 	private long updateTimestamp;
 	private String updateEndpoint;
 
@@ -57,8 +59,8 @@ public class ContentUpdateWorker extends RxWorker
 
 		updateType =
 			UpdateType.values()[workerParams.getInputData().getInt(INPUT_KEY_UPDATE_TYPE, UpdateType.DELTA.ordinal())];
-		updateTimestamp =
-			workerParams.getInputData().getLong(INPUT_KEY_UPDATE_TIMESTAMP, UPDATE_TIMESTAMP_UNINITIALIZED);
+		buildTimestamp = workerParams.getInputData().getLong(INPUT_KEY_BUILD_TIMESTAMP, TIMESTAMP_UNINITIALIZED);
+		updateTimestamp = workerParams.getInputData().getLong(INPUT_KEY_UPDATE_TIMESTAMP, TIMESTAMP_UNINITIALIZED);
 		updateEndpoint = workerParams.getInputData().getString(INPUT_KEY_UPDATE_ENDPOINT);
 
 		String workerImpl = workerParams.getInputData().getString(INPUT_KEY_UPDATE_MANAGER);
@@ -110,14 +112,28 @@ public class ContentUpdateWorker extends RxWorker
 		{
 			case FULL_BUNDLE:
 			{
-				workJob = updateManager.checkForBundle();
+				if (buildTimestamp == TIMESTAMP_UNINITIALIZED)
+				{
+					workJob = updateManager.checkForBundle(null);
+				}
+				else
+				{
+					workJob = updateManager.checkForBundle(buildTimestamp);
+				}
 				break;
 			}
 			case DELTA:
 			{
-				if (updateTimestamp == UPDATE_TIMESTAMP_UNINITIALIZED)
+				if (updateTimestamp == TIMESTAMP_UNINITIALIZED)
 				{
-					workJob = updateManager.checkForUpdates();
+					if (buildTimestamp == TIMESTAMP_UNINITIALIZED)
+					{
+						workJob = updateManager.checkForUpdatesToLocalContent(null);
+					}
+					else
+					{
+						workJob = updateManager.checkForUpdatesToLocalContent(buildTimestamp);
+					}
 				}
 				else
 				{

--- a/library/src/main/java/com/cube/storm/content/lib/worker/ContentUpdateWorker.java
+++ b/library/src/main/java/com/cube/storm/content/lib/worker/ContentUpdateWorker.java
@@ -126,14 +126,7 @@ public class ContentUpdateWorker extends RxWorker
 			{
 				if (updateTimestamp == TIMESTAMP_UNINITIALIZED)
 				{
-					if (buildTimestamp == TIMESTAMP_UNINITIALIZED)
-					{
-						workJob = updateManager.checkForUpdatesToLocalContent(null);
-					}
-					else
-					{
-						workJob = updateManager.checkForUpdatesToLocalContent(buildTimestamp);
-					}
+					workJob = updateManager.checkForUpdatesToLocalContent();
 				}
 				else
 				{

--- a/library/src/main/java/com/cube/storm/content/model/UpdateContentRequest.java
+++ b/library/src/main/java/com/cube/storm/content/model/UpdateContentRequest.java
@@ -37,13 +37,10 @@ public class UpdateContentRequest
 		return new UpdateContentRequest(id, ContentUpdateWorker.UpdateType.FULL_BUNDLE, buildTimestamp, null, progress);
 	}
 
-	public static UpdateContentRequest deltaUpdateFromLocalContent(
-		@Nullable Long buildTimestamp,
-		@NonNull Observable<UpdateContentProgress> progress
-	)
+	public static UpdateContentRequest deltaUpdateFromLocalContent(@NonNull Observable<UpdateContentProgress> progress)
 	{
 		String id = generateId();
-		return new UpdateContentRequest(id, ContentUpdateWorker.UpdateType.DELTA, buildTimestamp, null, progress);
+		return new UpdateContentRequest(id, ContentUpdateWorker.UpdateType.DELTA, null, null, progress);
 	}
 
 	public static UpdateContentRequest directDownload(@NonNull Observable<UpdateContentProgress> progress)

--- a/library/src/main/java/com/cube/storm/content/model/UpdateContentRequest.java
+++ b/library/src/main/java/com/cube/storm/content/model/UpdateContentRequest.java
@@ -1,17 +1,61 @@
 package com.cube.storm.content.model;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.cube.storm.ContentSettings;
 import com.cube.storm.content.lib.Environment;
 import com.cube.storm.content.lib.worker.ContentUpdateWorker;
 import io.reactivex.Observable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Value;
 
 @Value
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UpdateContentRequest
 {
+	private static String generateId()
+	{
+		return Long.toString(System.currentTimeMillis());
+	}
+
+	public static UpdateContentRequest deltaUpdate(
+		long contentTimestamp,
+		@NonNull Observable<UpdateContentProgress> progress
+	)
+	{
+		String id = generateId();
+		return new UpdateContentRequest(id, ContentUpdateWorker.UpdateType.DELTA, null, contentTimestamp, progress);
+	}
+
+	public static UpdateContentRequest fullBundle(
+		@Nullable Long buildTimestamp,
+		@NonNull Observable<UpdateContentProgress> progress
+	)
+	{
+		String id = generateId();
+		return new UpdateContentRequest(id, ContentUpdateWorker.UpdateType.FULL_BUNDLE, buildTimestamp, null, progress);
+	}
+
+	public static UpdateContentRequest deltaUpdateFromLocalContent(
+		@Nullable Long buildTimestamp,
+		@NonNull Observable<UpdateContentProgress> progress
+	)
+	{
+		String id = generateId();
+		return new UpdateContentRequest(id, ContentUpdateWorker.UpdateType.DELTA, buildTimestamp, null, progress);
+	}
+
+	public static UpdateContentRequest directDownload(@NonNull Observable<UpdateContentProgress> progress)
+	{
+		String id = generateId();
+		return new UpdateContentRequest(id, ContentUpdateWorker.UpdateType.DIRECT_DOWNLOAD, null, null, progress);
+	}
+
 	String id;
 	ContentUpdateWorker.UpdateType updateType;
-	Long timestamp;
+	Long buildTimestamp;
+	Long updateTimestamp;
 	Observable<UpdateContentProgress> progress;
 	Environment environment = ContentSettings.getInstance().getContentEnvironment();
 }


### PR DESCRIPTION
When downloading a full content bundle, Storm content lib would always download the absolute latest bundle. However, if there is no guarantee that the downloaded content would be compatible with the app binary that made the call.

For this reason this PR adds a new optional parameter `buildTimestamp` to the signature of the `checkBundle` method. If provided, this parameter will ensure only compatible bundles are downloaded by sending the parameter to the server, which will cross-check against landmark publishes.

