### PR TITLE
feature/update-gradle Fix: Update gradle to remove plugin deprecations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:4.0.1'
+		classpath 'com.android.tools.build:gradle:4.1.1'
 
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,3 +1,5 @@
+import com.cube.storm.content.BundleDownloadStrategy
+
 buildscript {
 	repositories {
 		maven { url "http://oss.3sidedcube.com:8081/artifactory/internal" }
@@ -44,7 +46,7 @@ android {
 			appId = "1"
 			bundleEnvironment = "live"
 			bundleTimestamp = null
-			bundleDownloadStrategy = com.cube.storm.content.BundleDownloadStrategy.IF_MISSING
+			bundleDownloadStrategy = BundleDownloadStrategy.IF_MISSING
 			authUsername = ""
 			authPassword = ""
 		}
@@ -66,7 +68,7 @@ dependencies {
 	implementation fileTree(dir: 'libs', include: ['*.jar'])
 	implementation project(':library')
 
-	implementation 'androidx.appcompat:appcompat:1.1.0'
+	implementation 'androidx.appcompat:appcompat:1.2.0'
 	implementation 'com.3sidedcube.storm:util:1.0.0'
 	implementation 'io.reactivex.rxjava2:rxjava:2.2.19'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.3.0
+VERSION_NAME=1.3.1-SNAPSHOT
 GROUP=com.3sidedcube.storm
 
 POM_NAME=LightningContent

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Aug 05 15:53:45 BST 2020
+#Mon Nov 16 17:57:06 CET 2020
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -12,10 +12,10 @@ repositories {
 }
 
 dependencies {
-    compile 'de.undercouch:gradle-download-task:3.4.3'
-    compile 'io.github.http-builder-ng:http-builder-ng-core:1.0.3'
-    compile 'org.apache.httpcomponents:httpclient:4.5.5'
-    testCompile 'junit:junit:4.12'
+    implementation 'de.undercouch:gradle-download-task:4.0.2'
+    implementation 'io.github.http-builder-ng:http-builder-ng-core:1.0.3'
+    implementation 'org.apache.httpcomponents:httpclient:4.5.6'
+    testImplementation 'junit:junit:4.13.1'
 }
 
 project.sourceCompatibility = '1.8'


### PR DESCRIPTION
**SUMMARY**

Update Gradle from the content library to remove the storm content plugin deprecations

**REASON**

ARCFA is using a deprecated Kotlin library (1.3.61) because when I try to update it, I have this error:

A problem occurred configuring project ':Codebase'.
org.gradle.internal.metaobject.AbstractDynamicObject$CustomMessageMissingMethodException: **Could not find method requestInterceptor()** for arguments [**com.cube.storm.content.RedirectInterceptor**@1ff55d40] on task ':Codebase:stormDownloadHttps___dev.arc.cubeapis.com_latest_apps_1_bundle_environment=live' of type de.undercouch.gradle.tasks.download.Download.

So, I think the deprecated Gradle for the content plugin could be the main problem. As you can see on this comparative

https://fossies.org/diffs/kotlin/1.3.61_vs_1.3.70/ChangeLog.md-diff.html

I suspect they could have removed this from 1.3.70 kotlin version:

- [`KT-32829`](https://youtrack.jetbrains.com/issue/KT-32829) "Add .jar to the classpath" quick fix creates "compile"/"testCompile" dependencies in build.gradle

