### PR TITLE
feature/update-gradle Fix: Allow insecure protocols and add the previous gradle-download-task version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ allprojects {
 
 		maven {
 			url 'http://oss.3sidedcube.com:8081/artifactory/internal'
+			allowInsecureProtocol = true
 		}
 
 		maven {
@@ -34,6 +35,7 @@ allprojects {
 				password "$ARTIFACTORY_PASSWORD"
 			}
 			url 'http://oss.3sidedcube.com:8081/artifactory/private'
+			allowInsecureProtocol = true
 		}
 	}
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -2,10 +2,13 @@ import com.cube.storm.content.BundleDownloadStrategy
 
 buildscript {
 	repositories {
-		maven { url "http://oss.3sidedcube.com:8081/artifactory/internal" }
+		maven {
+			url "http://oss.3sidedcube.com:8081/artifactory/internal"
+			allowInsecureProtocol = true
+		}
 	}
 	dependencies {
-		classpath 'com.3sidedcube.storm:content-gradle-plugin:+'
+		classpath 'com.3sidedcube.storm:content-gradle-plugin:1.0.4'
 	}
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.3.1-SNAPSHOT
+VERSION_NAME=1.3.1
 GROUP=com.3sidedcube.storm
 
 POM_NAME=LightningContent

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'groovy'
+	id "de.undercouch.download" version "3.4.3"
 }
 
 dependencies {
@@ -12,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'de.undercouch:gradle-download-task:4.0.2'
+    implementation 'de.undercouch:gradle-download-task:3.4.3'
     implementation 'io.github.http-builder-ng:http-builder-ng-core:1.0.3'
     implementation 'org.apache.httpcomponents:httpclient:4.5.6'
     testImplementation 'junit:junit:4.13.1'


### PR DESCRIPTION
**SUMMARY**

Added the insecure protocols flags because the artifactory is using HTTP instead of HTTPS, and add the previous version of gradle-download-task because some storm libraries are still using it.

