### PR TITLE
Feature/gradle 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:4.1.1'
+		classpath 'com.android.tools.build:gradle:7.0.0'
 
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:7.0.0'
+		classpath 'com.android.tools.build:gradle:7.0.3'
 
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files
@@ -15,8 +15,8 @@ buildscript {
 
 ext {
 	minSdkVersion = 16
-	compileSdkVersion = 30
-	targetSdkVersion = 30
+	compileSdkVersion = 31
+	targetSdkVersion = 31
 }
 
 allprojects {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 		}
 	}
 	dependencies {
-		classpath 'com.3sidedcube.storm:content-gradle-plugin:1.0.5.7-SNAPSHOT'
+		classpath 'com.3sidedcube.storm:content-gradle-plugin:1.0.5'
 	}
 }
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 		}
 	}
 	dependencies {
-		classpath 'com.3sidedcube.storm:content-gradle-plugin:1.0.4'
+		classpath 'com.3sidedcube.storm:content-gradle-plugin:1.0.5.7-SNAPSHOT'
 	}
 }
 

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
 		android:name=".ExampleApplication"
 		android:allowBackup="false"
 	>
-		<activity android:name=".ExampleActivity">
+		<activity android:name=".ExampleActivity" android:exported="true">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.3.1
+VERSION_NAME=1.3.2
 GROUP=com.3sidedcube.storm
 
 POM_NAME=LightningContent

--- a/gradle/artifactory.gradle
+++ b/gradle/artifactory.gradle
@@ -21,57 +21,12 @@
  * the License.
  */
 
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-def setupPomInfo(pom)
-{
-	pom.groupId = GROUP
-	pom.artifactId = POM_ARTIFACT_ID
-	pom.version = VERSION_NAME
-
-	pom.project {
-		name POM_NAME
-		packaging POM_PACKAGING
-		description POM_DESCRIPTION
-		url POM_URL
-
-		scm {
-			url POM_SCM_URL
-			connection POM_SCM_CONNECTION
-			developerConnection POM_SCM_DEV_CONNECTION
-		}
-
-		licenses {
-			license {
-				name POM_LICENSE_NAME
-				url POM_LICENSE_URL
-				distribution 'repo'
-			}
-		}
-
-		developers {
-			developer {
-				id POM_DEVELOPER_ID
-				name POM_DEVELOPER_NAME
-			}
-		}
-	}
-}
 allprojects {
 	tasks.withType(Javadoc) {
 		options.addStringOption('Xdoclint:none', '-quiet')
-	}
-}
-
-
-// Extra task definition is needed to work around naming conflict between maven and android plugins
-// http://stackoverflow.com/questions/18559932
-task installArchives(type: Upload) {
-	description "Installs artifacts to mavenLocal."
-	repositories.mavenInstaller {
-		configuration = configurations.default
-		setupPomInfo(pom)
 	}
 }
 
@@ -79,25 +34,55 @@ ext.ARTIFACTORY_USERNAME = properties.get('ARTIFACTORY_USERNAME', '')
 ext.ARTIFACTORY_PASSWORD = properties.get('ARTIFACTORY_PASSWORD', '')
 
 afterEvaluate { project ->
-	uploadArchives {
-		repositories {
-			mavenDeployer {
-				beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-				setupPomInfo(pom)
+	publishing {
+		publications {
+			mavenJava(MavenPublication) {
+				groupId = GROUP
+				artifactId = POM_ARTIFACT_ID
+				version = VERSION_NAME
 
-				repository(url: 'http://oss.3sidedcube.com:8081/artifactory/internal') {
-					authentication(userName: ARTIFACTORY_USERNAME, password: ARTIFACTORY_PASSWORD)
+				pom {
+					name = POM_NAME
+					packaging = POM_PACKAGING
+					description = POM_DESCRIPTION
+					url = POM_URL
+
+					scm {
+						url = POM_SCM_URL
+						connection = POM_SCM_CONNECTION
+						developerConnection = POM_SCM_DEV_CONNECTION
+					}
+
+					licenses {
+						license {
+							name = POM_LICENSE_NAME
+							url = POM_LICENSE_URL
+							distribution = 'repo'
+						}
+					}
+
+					developers {
+						developer {
+							id = POM_DEVELOPER_ID
+							name = POM_DEVELOPER_NAME
+						}
+					}
 				}
-
-				snapshotRepository(url: 'http://oss.3sidedcube.com:8081/artifactory/internal') {
-					authentication(userName: ARTIFACTORY_USERNAME, password: ARTIFACTORY_PASSWORD)
+			}
+		}
+		repositories {
+			maven {
+				url = "http://oss.3sidedcube.com:8081/artifactory/internal"
+				allowInsecureProtocol = true
+				credentials {
+					username = ARTIFACTORY_USERNAME
+					password = ARTIFACTORY_PASSWORD
 				}
 			}
 		}
 	}
 
 	signing {
-		required { gradle.taskGraph.hasTask("uploadArchives") }
-		sign configurations.archives
+		sign publishing.publications.mavenJava
 	}
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Nov 16 17:57:06 CET 2020
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -24,9 +24,9 @@ android {
 }
 
 dependencies {
-	implementation 'androidx.annotation:annotation:1.1.0'
-	implementation 'androidx.work:work-runtime:2.4.0'
-	implementation 'androidx.work:work-rxjava2:2.4.0'
+	implementation 'androidx.annotation:annotation:1.3.0'
+	implementation 'androidx.work:work-runtime:2.7.0'
+	implementation 'androidx.work:work-rxjava2:2.7.0'
 
 	implementation 'com.3sidedcube.storm:util:1.1.0-SNAPSHOT'
 
@@ -42,5 +42,69 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok:1.18.12'
 }
 
-//apply from: '../gradle/sonatype.gradle'
-apply from: '../gradle/artifactory.gradle'
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+allprojects {
+	tasks.withType(Javadoc) {
+		options.addStringOption('Xdoclint:none', '-quiet')
+	}
+}
+
+ext.ARTIFACTORY_USERNAME = properties.get('ARTIFACTORY_USERNAME', '')
+ext.ARTIFACTORY_PASSWORD = properties.get('ARTIFACTORY_PASSWORD', '')
+
+afterEvaluate { project ->
+	publishing {
+		publications {
+			mavenJava(MavenPublication) {
+				from components.release
+				groupId = GROUP
+				artifactId = POM_ARTIFACT_ID
+				version = VERSION_NAME
+
+				pom {
+					name = POM_NAME
+					packaging = POM_PACKAGING
+					description = POM_DESCRIPTION
+					url = POM_URL
+
+					scm {
+						url = POM_SCM_URL
+						connection = POM_SCM_CONNECTION
+						developerConnection = POM_SCM_DEV_CONNECTION
+					}
+
+					licenses {
+						license {
+							name = POM_LICENSE_NAME
+							url = POM_LICENSE_URL
+							distribution = 'repo'
+						}
+					}
+
+					developers {
+						developer {
+							id = POM_DEVELOPER_ID
+							name = POM_DEVELOPER_NAME
+						}
+					}
+				}
+			}
+		}
+		repositories {
+			maven {
+				url = "http://oss.3sidedcube.com:8081/artifactory/internal"
+				allowInsecureProtocol = true
+				credentials {
+					username = ARTIFACTORY_USERNAME
+					password = ARTIFACTORY_PASSWORD
+				}
+			}
+		}
+	}
+
+	signing {
+		sign publishing.publications.mavenJava
+	}
+}

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'groovy'
-	id "de.undercouch.download" version "3.4.3"
+    id 'java-library'
+	id "de.undercouch.download" version "4.1.2"
 }
 
 dependencies {
@@ -13,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'de.undercouch:gradle-download-task:4.1.1'
+    implementation 'de.undercouch:gradle-download-task:4.1.2'
     implementation 'io.github.http-builder-ng:http-builder-ng-core:1.0.3'
     implementation 'org.apache.httpcomponents:httpclient:4.5.6'
     testImplementation 'junit:junit:4.13.2'
@@ -25,6 +26,76 @@ project.targetCompatibility = '1.8'
 POM_NAME='LightningContentGradlePlugin'
 POM_ARTIFACT_ID='content-gradle-plugin'
 POM_PACKAGING='jar'
-VERSION_NAME="1.0.4"
+VERSION_NAME="1.0.5"
 
-apply from: '../gradle/artifactory.gradle'
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+allprojects {
+    tasks.withType(Javadoc) {
+        options.addStringOption('Xdoclint:none', '-quiet')
+    }
+}
+
+ext.ARTIFACTORY_USERNAME = properties.get('ARTIFACTORY_USERNAME', '')
+ext.ARTIFACTORY_PASSWORD = properties.get('ARTIFACTORY_PASSWORD', '')
+
+afterEvaluate { project ->
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                from components.java
+                groupId = GROUP
+                artifactId = POM_ARTIFACT_ID
+                version = VERSION_NAME
+
+                pom {
+                    name = POM_NAME
+                    packaging = POM_PACKAGING
+                    description = POM_DESCRIPTION
+                    url = POM_URL
+
+                    scm {
+                        url = POM_SCM_URL
+                        connection = POM_SCM_CONNECTION
+                        developerConnection = POM_SCM_DEV_CONNECTION
+                    }
+
+                    licenses {
+                        license {
+                            name = POM_LICENSE_NAME
+                            url = POM_LICENSE_URL
+                            distribution = 'repo'
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id = POM_DEVELOPER_ID
+                            name = POM_DEVELOPER_NAME
+                        }
+                    }
+                }
+            }
+        }
+        repositories {
+            maven {
+                url = "http://oss.3sidedcube.com:8081/artifactory/internal"
+                allowInsecureProtocol = true
+                credentials {
+                    username = ARTIFACTORY_USERNAME
+                    password = ARTIFACTORY_PASSWORD
+                }
+            }
+        }
+    }
+
+    signing {
+        sign publishing.publications.mavenJava
+    }
+}

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -13,10 +13,10 @@ repositories {
 }
 
 dependencies {
-    implementation 'de.undercouch:gradle-download-task:3.4.3'
+    implementation 'de.undercouch:gradle-download-task:4.1.1'
     implementation 'io.github.http-builder-ng:http-builder-ng-core:1.0.3'
     implementation 'org.apache.httpcomponents:httpclient:4.5.6'
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 project.sourceCompatibility = '1.8'

--- a/plugin/src/main/groovy/com/cube/storm/content/StormPlugin.groovy
+++ b/plugin/src/main/groovy/com/cube/storm/content/StormPlugin.groovy
@@ -126,7 +126,6 @@ class StormPlugin implements Plugin<Project> {
 					}
 					src mergedStormConfig.url
 					dest archiveDownloadLocation
-					requestInterceptor new RedirectInterceptor()
 					overwrite true
 				}
 				def unpackTask = project.task("stormUnpack${variant.name.capitalize()}Bundle", type: Copy, dependsOn: downloadTask) {


### PR DESCRIPTION
## What?
- Updated library versions to latest which support Gradle 7
- Updated publishing to use `maven-publish` which is required when using Gradle 7, seperated publishing into each individual module as `from components.java` wouldn't work with both the `:library` and `:plugin` modules
- Removed redirect interceptor as the latest library version doesn't support it and after testing, doesn't seem to be required.

## Why?
- So Storm projects can be upgraded to Gradle 7

## Testing?
- Tested on Nordstrom and Blood with `1.0.5.7-SNAPSHOT`

## Anything else?
- Getting `maven-publish` to actually upload the compiled `.jar` file was pretty infuriating but here we are.
- Will publish latest non-SNAPSHOT release once merged.