### PR TITLE
:URGENT: Fix/SP-982 configurable bundle validation

### DIFF
--- a/library/src/main/java/com/cube/storm/ContentSettings.java
+++ b/library/src/main/java/com/cube/storm/ContentSettings.java
@@ -9,8 +9,10 @@ import com.cube.storm.content.lib.factory.FileFactory;
 import com.cube.storm.content.lib.listener.DownloadListener;
 import com.cube.storm.content.lib.listener.UpdateListener;
 import com.cube.storm.content.lib.manager.APIManager;
+import com.cube.storm.content.lib.manager.BundleIntegrityManager;
 import com.cube.storm.content.lib.manager.DefaultMigrationManager;
 import com.cube.storm.content.lib.manager.DefaultUpdateManager;
+import com.cube.storm.content.lib.manager.LegacyBundleIntegrityManager;
 import com.cube.storm.content.lib.manager.MigrationManager;
 import com.cube.storm.content.lib.manager.UpdateManager;
 import com.cube.storm.content.lib.policy.PolicyEnforcingUpdateManager;
@@ -94,6 +96,11 @@ public class ContentSettings
 	 * Default {@link com.cube.storm.content.lib.manager.APIManager} to use throughout the module
 	 */
 	@Getter @Setter private APIManager apiManager;
+	
+	/**
+	 * Default {@link BundleIntegrityManager} to use throughout the module
+	 */
+	@Getter @Setter private BundleIntegrityManager bundleIntegrityManager;
 
 	/**
 	 * Default {@link com.cube.storm.content.lib.manager.UpdateManager} to use throughout the module
@@ -208,6 +215,7 @@ public class ContentSettings
 			migrationManager(new DefaultMigrationManager());
 			policyManager(new SharedPreferencesPolicyManager(this.context));
 			updateManager(new PolicyEnforcingUpdateManager(new DefaultUpdateManager()));
+			bundleIntegrityManager(new LegacyBundleIntegrityManager());
 
 			fileFactory(new FileFactory(){});
 			bundleBuilder(new BundleBuilder(){});
@@ -409,6 +417,17 @@ public class ContentSettings
 		public Builder policyManager(@NonNull PolicyManager manager)
 		{
 			construct.policyManager = manager;
+			return this;
+		}
+		
+		/**
+		 * Set the default {@link BundleIntegrityManager}
+		 * @param manager The new {@link BundleIntegrityManager} to use to validate and ensure integrity of bundles
+		 * @return The {@link com.cube.storm.ContentSettings.Builder} instance for chaining
+		 */
+		public Builder bundleIntegrityManager(@NonNull BundleIntegrityManager manager)
+		{
+			construct.bundleIntegrityManager = manager;
 			return this;
 		}
 

--- a/library/src/main/java/com/cube/storm/content/lib/helper/BundleHelper.java
+++ b/library/src/main/java/com/cube/storm/content/lib/helper/BundleHelper.java
@@ -11,6 +11,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 
 import java.io.File;
 import java.util.HashMap;
@@ -118,6 +119,13 @@ public class BundleHelper
 		return manifest.getTimestamp();
 	}
 	
+	/**
+	 * Remove any files from a bundle directory that are inside the expected folders of the bundle but are not found in the bundle manifest
+	 *
+	 * @param path The filepath to the bundle directory
+	 * @throws JsonSyntaxException if the bundle directory doesn't contain a parseable manifest
+	 * @throws IllegalStateException if the manifest in the bundle directory isn't formatted how it is expected to be
+	 */
 	public static void deleteUnexpectedFiles(File path)
 	{
 		File manifest = new File(path, Constants.FILE_MANIFEST);

--- a/library/src/main/java/com/cube/storm/content/lib/manager/BundleIntegrityManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/manager/BundleIntegrityManager.java
@@ -1,0 +1,26 @@
+package com.cube.storm.content.lib.manager;
+
+import java.io.File;
+
+/**
+ * Interface for ensuring that the integrity of any new bundle is verified before deployment and enforced after deployment
+ *
+ * @author JR Mitchell
+ */
+public interface BundleIntegrityManager
+{
+	/**
+	 * Checks the integrity of each file currently stored in the given directory, deleting all files from the directory if its integrity could not be verified
+	 *
+	 * @param contentPath the path to the bundle directory
+	 * @return true if the bundle has the correct integrity, false if it was deleted
+	 */
+	boolean integrityCheck(String contentPath);
+	
+	/**
+	 * Makes any final changes to the cached directory after deploying the bundle to enforce the integrity of the content
+	 *
+	 * @param cachePath the path to the directory that the bundle has been deployed into
+	 */
+	void enforceIntegrityAfterDeployment(File cachePath);
+}

--- a/library/src/main/java/com/cube/storm/content/lib/manager/DefaultUpdateManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/manager/DefaultUpdateManager.java
@@ -259,43 +259,9 @@ public class DefaultUpdateManager implements UpdateManager
 						{
 							observer.onNext(UpdateContentProgress.deploying());
 							// Move files from /delta to ../
-							FileHelper.copyDirectory(new File(getFilePath()), new File(ContentSettings.getInstance().getStoragePath()));
+							FileHelper.copyDirectory(new File(getFilePath()), path);
 							FileHelper.deleteRecursive(new File(getFilePath()));
-
-							File manifest = new File(path, Constants.FILE_MANIFEST);
-							JsonObject manifestJson = ContentSettings.getInstance().getFileManager().readFileAsJson(manifest).getAsJsonObject();
-
-							// Create map of expected data
-							Map<String, String[]> expectedContent = new HashMap<String, String[]>();
-							expectedContent.put("pages", new File(path + "/" + Constants.FOLDER_PAGES + "/").list());
-							expectedContent.put("languages", new File(path + "/" + Constants.FOLDER_LANGUAGES + "/").list());
-							expectedContent.put("content", new File(path + "/" + Constants.FOLDER_CONTENT + "/").list());
-							expectedContent.put("data", new File(path + "/" + Constants.FOLDER_DATA + "/").list());
-
-							for (String key : expectedContent.keySet())
-							{
-								if (manifestJson.has(key))
-								{
-									JsonArray pagesList = manifestJson.get(key).getAsJsonArray();
-
-									for (JsonElement e : pagesList)
-									{
-										String filename = e.getAsJsonObject().get("src").getAsString();
-
-										int size = expectedContent.get(key) == null ? 0 : expectedContent.get(key).length;
-										for (int index = 0; index < size; index++)
-										{
-											if (expectedContent.get(key)[index] != null && expectedContent.get(key)[index].equals(filename))
-											{
-												expectedContent.get(key)[index] = null;
-												break;
-											}
-										}
-									}
-
-									FileHelper.removeFiles(path + "/" + key + "/", expectedContent.get(key));
-								}
-							}
+							BundleHelper.deleteUnexpectedFiles(path);
 						}
 						observer.onComplete();
 					}

--- a/library/src/main/java/com/cube/storm/content/lib/manager/DefaultUpdateManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/manager/DefaultUpdateManager.java
@@ -255,13 +255,15 @@ public class DefaultUpdateManager implements UpdateManager
 
 						File path = new File(ContentSettings.getInstance().getStoragePath());
 
-						if (BundleHelper.integrityCheck(getFilePath()))
+						// Check the integrity of the unpacked bundle
+						if (ContentSettings.getInstance().getBundleIntegrityManager().integrityCheck(getFilePath()))
 						{
 							observer.onNext(UpdateContentProgress.deploying());
 							// Move files from /delta to ../
 							FileHelper.copyDirectory(new File(getFilePath()), path);
 							FileHelper.deleteRecursive(new File(getFilePath()));
-							BundleHelper.deleteUnexpectedFiles(path);
+							// Enforce the integrity of the deployed directory
+							ContentSettings.getInstance().getBundleIntegrityManager().enforceIntegrityAfterDeployment(path);
 						}
 						observer.onComplete();
 					}

--- a/library/src/main/java/com/cube/storm/content/lib/manager/LegacyBundleIntegrityManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/manager/LegacyBundleIntegrityManager.java
@@ -1,0 +1,25 @@
+package com.cube.storm.content.lib.manager;
+
+import com.cube.storm.content.lib.helper.BundleHelper;
+
+import java.io.File;
+
+/**
+ * {@link BundleIntegrityManager} implementation based on the pre-existing Storm logic from before the introduction of {@link BundleIntegrityManager}
+ * {@link LegacyBundleIntegrityManager#integrityCheck(String)} leverages {@link BundleHelper#integrityCheck(String)} to ensure that every file listed in the manifest matches the hash of that file in the bundle
+ * {@link LegacyBundleIntegrityManager#enforceIntegrityAfterDeployment(File)} leverages {@link BundleHelper#deleteUnexpectedFiles(File)} to delete any files in the cache that are not listed in the manifest
+ *
+ * @author JR Mitchell
+ */
+public class LegacyBundleIntegrityManager implements BundleIntegrityManager
+{
+	@Override public boolean integrityCheck(String contentPath)
+	{
+		return BundleHelper.integrityCheck(contentPath);
+	}
+	
+	@Override public void enforceIntegrityAfterDeployment(File cachePath)
+	{
+		BundleHelper.deleteUnexpectedFiles(cachePath);
+	}
+}


### PR DESCRIPTION
### What?

- Moved unexpected file deletion logic from `DefaultUpdateManager.downloadUpdates()` to new static method `BundleHelper.deleteUnexpectedFiles()`, and tidy / fix up its logic a little
- Add new `BundleIntegrityManager.java` interface, with method for verifying integrity of a bundle prior to deployment, and method for enforcing integrity of the cache after deployment
- Update `ContentSettings` and its `Builder` so that an instance `BundleIntegrityManager` can be provided and configured
- Update `DefaultUpdateManager.downloadUpdates()` so that it calls on `ContentSettings.getBundleIntegrityManager()` for integrity verification and integrity enforcement
- Add `LegacyBundleIntegrityManager.java` concrete implementation of `BundleIntegrityManager`, which implements it in such a way that matches the behaviour of Storm prior to this change; this is also used as the default manager in `ContentSettings.Builder` so as to not change the existing behaviour of any Storm apps unless they manually change the manager

### Why?

This allows apps to specify custom integrity validation based on their own criteria.
