### PR TITLE
:HIGH: Fix/SEC-584 update rxjava version [Medium PR]

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -79,7 +79,6 @@ dependencies {
 	implementation project(':library')
 
 	implementation 'androidx.appcompat:appcompat:1.7.1'
-	implementation 'io.reactivex.rxjava2:rxjava:2.2.21'
 
 	compileOnly 'org.projectlombok:lombok:1.18.40'
 	annotationProcessor 'org.projectlombok:lombok:1.18.40'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -80,6 +80,6 @@ dependencies {
 
 	implementation 'androidx.appcompat:appcompat:1.7.1'
 
-	compileOnly 'org.projectlombok:lombok:1.18.40'
-	annotationProcessor 'org.projectlombok:lombok:1.18.40'
+	compileOnly 'org.projectlombok:lombok:1.18.46'
+	annotationProcessor 'org.projectlombok:lombok:1.18.46'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.0.0
+VERSION_NAME=3.0.0-rc1
 GROUP=com.3sidedcube.storm
 
 POM_NAME=LightningContent

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=3.0.0-rc1
+VERSION_NAME=3.0.0-rc2
 GROUP=com.3sidedcube.storm
 
 POM_NAME=LightningContent

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -31,12 +31,11 @@ android {
 dependencies {
 	implementation 'androidx.annotation:annotation:1.9.1'
 	implementation 'androidx.work:work-runtime:2.10.4'
-	implementation 'androidx.work:work-rxjava2:2.10.4'
+	implementation 'androidx.work:work-rxjava3:2.10.4'
 
 	implementation 'com.3sidedcube.storm:util:1.3.0'
 
-	implementation 'io.reactivex.rxjava2:rxjava:2.2.21'
-	implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
+	implementation 'io.reactivex.rxjava3:rxjava:3.1.9'
 
 	implementation 'com.google.code.gson:gson:2.13.2'
 	implementation 'org.kamranzafar:jtar:2.3'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -29,20 +29,20 @@ android {
 }
 
 dependencies {
-	implementation 'androidx.annotation:annotation:1.9.1'
-	implementation 'androidx.work:work-runtime:2.10.4'
-	implementation 'androidx.work:work-rxjava3:2.10.4'
+	implementation 'androidx.annotation:annotation:1.10.0'
+	implementation 'androidx.work:work-runtime:2.11.2'
+	implementation 'androidx.work:work-rxjava3:2.11.2'
 
 	implementation 'com.3sidedcube.storm:util:1.3.0'
 
-	implementation 'io.reactivex.rxjava3:rxjava:3.1.9'
+	implementation 'io.reactivex.rxjava3:rxjava:3.1.12'
 
-	implementation 'com.google.code.gson:gson:2.13.2'
+	implementation 'com.google.code.gson:gson:2.14.0'
 	implementation 'org.kamranzafar:jtar:2.3'
 	implementation 'com.jakewharton.timber:timber:5.0.1'
-	implementation 'com.squareup.okhttp3:okhttp:5.3.2'
+	implementation 'com.squareup.okhttp3:okhttp:5.4.0'
 
-	compileOnly 'org.projectlombok:lombok:1.18.40'
-	annotationProcessor 'org.projectlombok:lombok:1.18.40'
+	compileOnly 'org.projectlombok:lombok:1.18.46'
+	annotationProcessor 'org.projectlombok:lombok:1.18.46'
 }
 apply from: '../gradle/publishing.gradle'

--- a/library/src/main/java/com/cube/storm/content/lib/helper/BundleHelper.java
+++ b/library/src/main/java/com/cube/storm/content/lib/helper/BundleHelper.java
@@ -17,8 +17,6 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
-import timber.log.Timber;
-
 /**
  * Utility methods relating to Storm content bundles and their contents
  */
@@ -29,7 +27,6 @@ public class BundleHelper
 	 */
 	public static void clearCache()
 	{
-		Timber.tag("storm_diagnostics").i("Clearing cached content");
 		String path = ContentSettings.getInstance().getStoragePath();
 		FileHelper.deleteRecursive(new File(path, "pages/"));
 		FileHelper.deleteRecursive(new File(path, "data/"));

--- a/library/src/main/java/com/cube/storm/content/lib/manager/APIManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/manager/APIManager.java
@@ -79,6 +79,7 @@ public abstract class APIManager
 		String urlPart = String.format(Constants.API_CONTENT_UPDATE, appId, lastUpdate, ContentSettings.getInstance().getContentEnvironment().getEnvironmentLabel());
 
 		Headers.Builder builder = new Headers.Builder();
+		builder.add("Connection", "close");
 
 		if (ContentSettings.getInstance().getContentEnvironment() == Environment.TEST)
 		{
@@ -97,7 +98,7 @@ public abstract class APIManager
 			Request.Builder request = new Request.Builder()
 				.url(url.toString())
 				.get()
-				.header("Connection", "close");
+				.headers(builder.build());
 
 			// Get the response
 			Call call = httpClient.newCall(request.build());
@@ -159,6 +160,7 @@ public abstract class APIManager
 		}
 
 		Headers.Builder builder = new Headers.Builder();
+		builder.add("Connection", "close");
 
 		if (ContentSettings.getInstance().getContentEnvironment() == Environment.TEST)
 		{
@@ -176,7 +178,7 @@ public abstract class APIManager
 			Request.Builder request = new Request.Builder()
 				.url(url.toString())
 				.get()
-				.header("Connection", "close");
+				.headers(builder.build());
 
 			// Get the response
 			Call call = httpClient.newCall(request.build());

--- a/library/src/main/java/com/cube/storm/content/lib/manager/DefaultUpdateManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/manager/DefaultUpdateManager.java
@@ -12,10 +12,10 @@ import com.cube.storm.content.model.UpdateContentProgress;
 import com.cube.storm.content.model.UpdateContentRequest;
 import com.google.gson.JsonElement;
 
-import io.reactivex.Observable;
-import io.reactivex.Observer;
-import io.reactivex.subjects.BehaviorSubject;
-import io.reactivex.subjects.Subject;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Observer;
+import io.reactivex.rxjava3.subjects.BehaviorSubject;
+import io.reactivex.rxjava3.subjects.Subject;
 import okhttp3.Call;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;

--- a/library/src/main/java/com/cube/storm/content/lib/manager/UpdateManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/manager/UpdateManager.java
@@ -4,7 +4,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.cube.storm.content.lib.helper.BundleHelper;
 import com.cube.storm.content.model.UpdateContentRequest;
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 
 /**
  * This is the manager class responsible for checking for and downloading updates from the server

--- a/library/src/main/java/com/cube/storm/content/lib/policy/PolicyEnforcingUpdateManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/policy/PolicyEnforcingUpdateManager.java
@@ -5,7 +5,7 @@ import androidx.annotation.Nullable;
 import com.cube.storm.ContentSettings;
 import com.cube.storm.content.lib.manager.UpdateManager;
 import com.cube.storm.content.model.UpdateContentRequest;
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 
 /**
  * {@link UpdateManager} which ensures updates only occur on a wi-fi connection, otherwise delegating to another

--- a/library/src/main/java/com/cube/storm/content/lib/push/ContentAvailablePushHandler.java
+++ b/library/src/main/java/com/cube/storm/content/lib/push/ContentAvailablePushHandler.java
@@ -3,7 +3,6 @@ package com.cube.storm.content.lib.push;
 import com.cube.storm.ContentSettings;
 import com.cube.storm.content.lib.Environment;
 import com.cube.storm.content.lib.helper.BundleHelper;
-import timber.log.Timber;
 
 import java.util.Map;
 
@@ -34,8 +33,6 @@ public class ContentAvailablePushHandler
 	 */
 	public static void handleContentAvailablePush(Map<String, String> data)
 	{
-		Timber.tag("storm_diagnostics").i("Handling content available push: " + data.toString());
-
 		if (ContentSettings.getInstance().getContentEnvironment() != Environment.LIVE)
 		{
 			return;
@@ -47,7 +44,6 @@ public class ContentAvailablePushHandler
 
 		if (remoteEndpoint == null || remoteTimestampString == null)
 		{
-			Timber.tag("storm_diagnostics").i("Content available push invalid");
 			return;
 		}
 
@@ -59,27 +55,21 @@ public class ContentAvailablePushHandler
 
 		if (localTimestamp == null)
 		{
-			Timber.tag("storm_diagnostics").i("Local bundle timestamp not found");
 			return;
 		}
-
-		Timber.tag("storm_diagnostics").i("Local bundle timestamp: " + localTimestamp);
 
 		// If the remote bundle is earlier or the same as our local one then stop
 		if (localTimestamp >= remoteTimestamp)
 		{
-			Timber.tag("storm_diagnostics").i("App already up-to-date");
 			return;
 		}
 
 		// If the local bundle is not allowed to upgrade to the remote bundle because of a landmark publish then stop
 		if (localTimestamp < previousLandmarkTimestamp)
 		{
-			Timber.tag("storm_diagnostics").i("App cannot update this far");
 			return;
 		}
 
-		Timber.tag("storm_diagnostics").i("Downloading from " + remoteEndpoint);
 		ContentSettings.getInstance().getUpdateManager().downloadUpdates(remoteEndpoint);
 	}
 }

--- a/library/src/main/java/com/cube/storm/content/lib/worker/BackgroundWorkerObserver.java
+++ b/library/src/main/java/com/cube/storm/content/lib/worker/BackgroundWorkerObserver.java
@@ -5,8 +5,8 @@ import com.cube.storm.content.model.UpdateContentProgress;
 import androidx.lifecycle.LiveData;
 import androidx.work.Data;
 import androidx.work.WorkInfo;
-import io.reactivex.subjects.BehaviorSubject;
-import io.reactivex.subjects.Subject;
+import io.reactivex.rxjava3.subjects.BehaviorSubject;
+import io.reactivex.rxjava3.subjects.Subject;
 import lombok.Getter;
 
 /**

--- a/library/src/main/java/com/cube/storm/content/lib/worker/BackgroundWorkerUpdateManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/worker/BackgroundWorkerUpdateManager.java
@@ -19,9 +19,9 @@ import com.cube.storm.ContentSettings;
 import com.cube.storm.content.lib.manager.UpdateManager;
 import com.cube.storm.content.model.UpdateContentProgress;
 import com.cube.storm.content.model.UpdateContentRequest;
-import io.reactivex.Observable;
-import io.reactivex.subjects.BehaviorSubject;
-import io.reactivex.subjects.Subject;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.subjects.BehaviorSubject;
+import io.reactivex.rxjava3.subjects.Subject;
 import timber.log.Timber;
 
 import java.util.UUID;

--- a/library/src/main/java/com/cube/storm/content/lib/worker/BackgroundWorkerUpdateManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/worker/BackgroundWorkerUpdateManager.java
@@ -22,7 +22,6 @@ import com.cube.storm.content.model.UpdateContentRequest;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.subjects.BehaviorSubject;
 import io.reactivex.rxjava3.subjects.Subject;
-import timber.log.Timber;
 
 import java.util.UUID;
 
@@ -132,7 +131,6 @@ public class BackgroundWorkerUpdateManager implements UpdateManager
 	public UpdateContentRequest checkForBundle(@Nullable Long buildTimestamp)
 	{
 		OneTimeWorkRequest workRequest = createOneTimeWorkRequest(FULL_BUNDLE, buildTimestamp, null, null);
-		log(String.format("Enqueuing bundle check (%s)", workRequest.getId().toString()));
 		workManager.enqueueUniqueWork(CONTENT_CHECK_WORK_NAME, ExistingWorkPolicy.REPLACE, workRequest);
 		Observable<UpdateContentProgress> progressObservable = createWorkObservable(workRequest.getId());
 		UpdateContentRequest updateContentRequest = UpdateContentRequest.fullBundle(buildTimestamp, progressObservable);
@@ -144,7 +142,6 @@ public class BackgroundWorkerUpdateManager implements UpdateManager
 	public UpdateContentRequest checkForUpdatesToLocalContent()
 	{
 		OneTimeWorkRequest workRequest = createOneTimeWorkRequest(DELTA, null, null, null);
-		log(String.format("Enqueuing update check (%s)", workRequest.getId().toString()));
 		workManager.enqueueUniqueWork(CONTENT_CHECK_WORK_NAME, ExistingWorkPolicy.REPLACE, workRequest);
 		Observable<UpdateContentProgress> progressObservable = createWorkObservable(workRequest.getId());
 		UpdateContentRequest updateContentRequest = UpdateContentRequest.deltaUpdateFromLocalContent(progressObservable);
@@ -156,7 +153,6 @@ public class BackgroundWorkerUpdateManager implements UpdateManager
 	public UpdateContentRequest checkForUpdates(long lastUpdate)
 	{
 		OneTimeWorkRequest workRequest = createOneTimeWorkRequest(DELTA, null, lastUpdate, null);
-		log(String.format("Enqueuing update check from %d (%s)", lastUpdate, workRequest.getId().toString()));
 		workManager.enqueueUniqueWork(CONTENT_CHECK_WORK_NAME, ExistingWorkPolicy.REPLACE, workRequest);
 		Observable<UpdateContentProgress> progressObservable = createWorkObservable(workRequest.getId());
 		UpdateContentRequest updateContentRequest = UpdateContentRequest.deltaUpdate(lastUpdate, progressObservable);
@@ -178,7 +174,6 @@ public class BackgroundWorkerUpdateManager implements UpdateManager
 	public UpdateContentRequest downloadUpdates(@NonNull String endpoint)
 	{
 		OneTimeWorkRequest workRequest = createOneTimeWorkRequest(DIRECT_DOWNLOAD, null, null, endpoint);
-		log(String.format("Enqueuing download from %s (%s)", endpoint, workRequest.getId().toString()));
 		workManager.enqueueUniqueWork(CONTENT_CHECK_WORK_NAME, ExistingWorkPolicy.APPEND, workRequest);
 		Observable<UpdateContentProgress> progressObservable = createWorkObservable(workRequest.getId());
 		UpdateContentRequest updateContentRequest = UpdateContentRequest.directDownload(progressObservable);
@@ -186,15 +181,9 @@ public class BackgroundWorkerUpdateManager implements UpdateManager
 		return updateContentRequest;
 	}
 
-	private void log(String s)
-	{
-		Timber.tag("storm_diagnostics").i(s);
-	}
-
 	@Override
 	public void scheduleBackgroundUpdates()
 	{
-		log("Scheduling background content updates");
 		PeriodicWorkRequest workRequest = createPeriodicWorkRequest();
 		workManager.enqueueUniquePeriodicWork(CONTENT_CHECK_SCHEDULE_NAME,
 		                                      ExistingPeriodicWorkPolicy.REPLACE,

--- a/library/src/main/java/com/cube/storm/content/lib/worker/ContentUpdateWorker.java
+++ b/library/src/main/java/com/cube/storm/content/lib/worker/ContentUpdateWorker.java
@@ -3,12 +3,12 @@ package com.cube.storm.content.lib.worker;
 import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.work.Data;
-import androidx.work.RxWorker;
+import androidx.work.rxjava3.RxWorker;
 import androidx.work.WorkerParameters;
 import com.cube.storm.content.lib.manager.DefaultUpdateManager;
 import com.cube.storm.content.lib.manager.UpdateManager;
 import com.cube.storm.content.model.UpdateContentRequest;
-import io.reactivex.Single;
+import io.reactivex.rxjava3.core.Single;
 import timber.log.Timber;
 
 /**
@@ -149,7 +149,7 @@ public class ContentUpdateWorker extends RxWorker
 
 		return workJob
 			       .getProgress()
-			       .doOnNext(updateContentProgress -> this.setProgress(updateContentProgress.toWorkerData()))
+			       .doOnNext(updateContentProgress -> this.setCompletableProgress(updateContentProgress.toWorkerData()))
 			       .ignoreElements()
 			       .toSingleDefault(Result.success())
 			       .doOnSuccess(result -> log("Success"))

--- a/library/src/main/java/com/cube/storm/content/lib/worker/ContentUpdateWorker.java
+++ b/library/src/main/java/com/cube/storm/content/lib/worker/ContentUpdateWorker.java
@@ -9,7 +9,6 @@ import com.cube.storm.content.lib.manager.DefaultUpdateManager;
 import com.cube.storm.content.lib.manager.UpdateManager;
 import com.cube.storm.content.model.UpdateContentRequest;
 import io.reactivex.rxjava3.core.Single;
-import timber.log.Timber;
 
 /**
  * Background worker responsible for performing a task relating to content updates.
@@ -96,7 +95,6 @@ public class ContentUpdateWorker extends RxWorker
 		}
 		catch (Throwable err)
 		{
-			log(err);
 			return Single.just(Result.failure());
 		}
 	}
@@ -104,8 +102,6 @@ public class ContentUpdateWorker extends RxWorker
 	@NonNull
 	private Single<Result> doCreateWork()
 	{
-		log("started with " + updateManager);
-
 		UpdateContentRequest workJob = null;
 
 		switch (updateType)
@@ -143,7 +139,6 @@ public class ContentUpdateWorker extends RxWorker
 
 		if (workJob == null)
 		{
-			log("No job to perform");
 			return Single.just(Result.failure());
 		}
 
@@ -152,27 +147,8 @@ public class ContentUpdateWorker extends RxWorker
 			       .doOnNext(updateContentProgress -> this.setCompletableProgress(updateContentProgress.toWorkerData()))
 			       .ignoreElements()
 			       .toSingleDefault(Result.success())
-			       .doOnSuccess(result -> log("Success"))
-			       .doOnError(this::log)
 			       .onErrorReturn(err -> Result.failure(new Data.Builder()
 				                                            .putString("error", err.getMessage())
 				                                            .build()));
-	}
-
-	@Override
-	public void onStopped()
-	{
-		super.onStopped();
-		log("stopped");
-	}
-
-	private void log(String s)
-	{
-		Timber.tag("storm_diagnostics").i("Background worker " + this.getId().toString() + " " + s);
-	}
-
-	private void log(Throwable err)
-	{
-		Timber.tag("storm_diagnostics").i(err, "Background worker " + this.getId().toString() + " error");
 	}
 }

--- a/library/src/main/java/com/cube/storm/content/model/UpdateContentRequest.java
+++ b/library/src/main/java/com/cube/storm/content/model/UpdateContentRequest.java
@@ -5,7 +5,7 @@ import androidx.annotation.Nullable;
 import com.cube.storm.ContentSettings;
 import com.cube.storm.content.lib.Environment;
 import com.cube.storm.content.lib.worker.ContentUpdateWorker;
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Value;

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'groovy'
     id 'java-library'
-	id "de.undercouch.download" version "5.6.0"
+	id "de.undercouch.download" version "5.7.0"
 }
 
 dependencies {
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'de.undercouch:gradle-download-task:5.6.0'
+    implementation 'de.undercouch:gradle-download-task:5.7.0'
     implementation 'io.github.http-builder-ng:http-builder-ng-core:1.0.4'
     implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
## What?

Chores:
 - Bumps the versions of dependencies 
 - Removes timber logs 
 - Bumps the version to `v3.0.0-rc2` 

Fixes:
 - Migrates from `RxJava2` to `RxJava3` 
 - Updates `APIManager.java` to ensure that all headers are used in calls to get the bundle or the bundle delta 

## Why?

RxJava2 reached end-of-life in 2021.
This PR updates to RxJava3.
It also bumps versions of other dependencies, fixes an oversight in `APIManager` in v2.0.0 that resulted in developer mode not working, and removes some Timber logs which were not going anywhere anyway, which are all just nice fixes to have.

## Anything Else?

I will bump to v3.0.0 and release once it's been successfully tested