### PR TITLE
:NORMAL: Feature/AGP 9 Content Gradle Plugin Migration [MEDIUM]

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 		}
 	}
 	dependencies {
-		classpath 'com.3sidedcube.storm:content-gradle-plugin:1.0.6'
+		classpath 'com.3sidedcube.storm:content-gradle-plugin:2.0.0'
 	}
 }
 
@@ -56,10 +56,11 @@ android {
 			authUsername = ""
 			authPassword = ""
 		}
+	}
 
-		buildFeatures {
-			buildConfig = true
-		}
+	// Required for the Storm plugin to inject its STORM_* BuildConfig fields.
+	buildFeatures {
+		buildConfig = true
 	}
 
 	compileOptions {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -10,10 +10,15 @@ dependencies {
 }
 
 repositories {
+    google()
     mavenCentral()
 }
 
 dependencies {
+    // Compile against the stable Android Gradle variant API (AndroidComponents / onVariants).
+    // compileOnly so the consuming app's own AGP (8.x or 9.x) provides the implementation at runtime.
+    compileOnly 'com.android.tools.build:gradle-api:8.13.0'
+
     implementation 'de.undercouch:gradle-download-task:5.7.0'
     implementation 'io.github.http-builder-ng:http-builder-ng-core:1.0.4'
     implementation 'org.apache.httpcomponents:httpclient:4.5.14'
@@ -23,7 +28,8 @@ dependencies {
 POM_NAME='LightningContentGradlePlugin'
 POM_ARTIFACT_ID='content-gradle-plugin'
 POM_PACKAGING='jar'
-VERSION_NAME="1.0.5"
+// 2.0.0: migrated to the AndroidComponents variant API. Requires AGP 7.2+ (supports AGP 9.x).
+VERSION_NAME="2.0.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/plugin/src/main/groovy/com/cube/storm/content/StormPlugin.groovy
+++ b/plugin/src/main/groovy/com/cube/storm/content/StormPlugin.groovy
@@ -1,10 +1,11 @@
 package com.cube.storm.content
 
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
+import com.android.build.api.variant.BuildConfigField
 import de.undercouch.gradle.tasks.download.Download
 import groovyx.net.http.NativeHandlers
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.tasks.Copy
 
 import static groovyx.net.http.ContentTypes.JSON
 import static groovyx.net.http.HttpBuilder.configure
@@ -33,7 +34,7 @@ class StormPlugin implements Plugin<Project> {
 		 * - authPassword - Password to auth with
 		 */
 		String authToken = null
-		def authTask = project.task("stormAuthenticate") {
+		def authTask = project.tasks.register("stormAuthenticate") {
 			doLast {
 				String uri = "https://auth.cubeapis.com/v1.6/authentication"
 				println "Authenticating ${project.android.defaultConfig.storm.authUsername} at ${uri}"
@@ -54,123 +55,173 @@ class StormPlugin implements Plugin<Project> {
 			}
 		}
 
-		/**
-		 * Create download and unpack tasks for each unique app variant
-		 */
-		project.android.applicationVariants.all { variant ->
+		def android = project.android
 
-			def mergedStormConfig = new StormExtension()
+		// Capture invocation state at configuration time so the task predicates below don't touch the
+		// Project object at execution time (which the Gradle 9 configuration cache forbids).
+		boolean offline = project.gradle.startParameter.isOffline()
+		boolean explicitStormRequest = project.gradle.startParameter.taskNames.any { name -> name.startsWith("storm") }
+
+		/**
+		 * Create download and unpack tasks for each unique app variant.
+		 *
+		 * Migrated from the legacy {@code android.applicationVariants} iterator (removed in AGP 9) to the
+		 * stable {@code AndroidComponents.onVariants} API, which exists since AGP 7.2 and so supports
+		 * AGP 7.2 -> 9.x from a single code path.
+		 */
+		def androidComponents = project.extensions.getByType(ApplicationAndroidComponentsExtension)
+		androidComponents.onVariants(androidComponents.selector().all()) { variant ->
 
 			/**
 			 * First of all merge all the Storm configuations for this bundle together. These come from (in order of priority):
 			 * 1) the build type for the variant (e.g. debug / release)
 			 * 2) each flavor comprising the variant
 			 * 3) the Android default config
+			 *
+			 * The new variant API exposes the build type and flavors by name only, so the DSL objects that
+			 * carry the merged {@code storm { }} extension are looked up back off the android extension.
 			 */
-			mergedStormConfig = mergedStormConfig.merge(variant.buildType.storm)
-			variant.productFlavors.each { flavor ->
-				mergedStormConfig = mergedStormConfig.merge(flavor.storm)
+			def mergedStormConfig = new StormExtension()
+
+			def buildType = android.buildTypes.findByName(variant.buildType)
+			if (buildType?.storm != null) {
+				mergedStormConfig = mergedStormConfig.merge(buildType.storm)
 			}
-			mergedStormConfig = mergedStormConfig.merge(project.android.defaultConfig.storm)
-			mergedStormConfig = mergedStormConfig.merge(new StormExtension(bundleDownloadStrategy: variant.buildType.name == "release" ? BundleDownloadStrategy.ALWAYS : BundleDownloadStrategy.IF_MISSING))
-
-			if (mergedStormConfig.isValid()) {
-				println "Storm configuration for \"${variant.name}\": ${mergedStormConfig}"
-
-				String sanitisedUrl = mergedStormConfig.url.replaceAll("[\\\\/:*?\"<>|]", "_")
-				String archiveDownloadLocation = "${project.buildDir}/storm/${sanitisedUrl}/bundle.tar.gz"
-				String bundleUnpackDir = "${project.projectDir}/src/${variant.name}/assets"
-				String downloadTaskName = "stormDownload${sanitisedUrl.capitalize()}"
-
-				def downloadTask = project.tasks.findByName(downloadTaskName) ?: project.task(downloadTaskName, type: Download, dependsOn: mergedStormConfig.requiresAuth() ? authTask : null) {
-					/**
-					 * Only download if the flag to enable downloading on every assembly is explicitly requested
-					 */
-					onlyIf {
-						if (project.gradle.startParameter.isOffline()) {
-							println "Skipping bundle download in offline mode"
-							return false
-						}
-
-						// Always download if explicitly requested
-						if (project.gradle.startParameter.taskNames.any { name -> name.startsWith("storm") }) {
-							println "Explicitly requested download"
-							return true
-						}
-
-						switch (mergedStormConfig.bundleDownloadStrategy) {
-							case BundleDownloadStrategy.ALWAYS:
-								println "Downloading bundle as strategy is set to ALWAYS"
-								return true
-							case BundleDownloadStrategy.IF_MISSING:
-								if (project.file(archiveDownloadLocation).exists()) {
-									println "Skipping bundle download as cached archive exists on disk and strategy is IF_MISSING"
-									return false
-								} else {
-									println "Downloading initial bundle as no cached copy exists and strategy is IF_MISSING"
-									return true
-								}
-							case BundleDownloadStrategy.NEVER:
-								println "Skipping bundle download as strategy is set to NEVER"
-								return false
-						}
-
-						return false
-					}
-					doFirst {
-						println "Downloading from ${src}..."
-						if (mergedStormConfig.requiresAuth()) {
-							println "Setting auth token for user ${mergedStormConfig.authUsername}: ${authToken}"
-							header "Authorization", authToken
-						}
-					}
-					src mergedStormConfig.url
-					dest archiveDownloadLocation
-					overwrite true
+			variant.productFlavors.each { flavorPair ->
+				def flavor = android.productFlavors.findByName(flavorPair.second)
+				if (flavor?.storm != null) {
+					mergedStormConfig = mergedStormConfig.merge(flavor.storm)
 				}
-				def unpackTask = project.task("stormUnpack${variant.name.capitalize()}Bundle", type: Copy, dependsOn: downloadTask) {
-					onlyIf {
-						// Always unpack if explicitly requested
-						if (project.gradle.startParameter.taskNames.any { name -> name.startsWith("storm") }) {
-							println "Explicitly requested unpack"
-							return true
-						}
+			}
+			mergedStormConfig = mergedStormConfig.merge(android.defaultConfig.storm)
+			mergedStormConfig = mergedStormConfig.merge(new StormExtension(bundleDownloadStrategy: variant.buildType == "release" ? BundleDownloadStrategy.ALWAYS : BundleDownloadStrategy.IF_MISSING))
 
-						switch (mergedStormConfig.bundleDownloadStrategy) {
-							case BundleDownloadStrategy.ALWAYS:
-								println "Unpacking bundle as strategy is set to ALWAYS"
-								return true
-							case BundleDownloadStrategy.IF_MISSING:
-								if (project.file("${bundleUnpackDir}/manifest.json").exists()) {
-									println "Skipping bundle unpack as copy already exists in assets dir and strategy is IF_MISSING"
-									return false
-								} else {
-									println "Unpacking initial bundle as no copy exists in assets dir and strategy is IF_MISSING"
-									return true
-								}
-							case BundleDownloadStrategy.NEVER:
-								println "Skipping bundle unpack as strategy is set to NEVER"
-								return false
-						}
-
-						return false
-					}
-					from project.tarTree(project.resources.gzip(downloadTask.dest))
-					into bundleUnpackDir
-				}
-
-				project.tasks."generate${variant.name.capitalize()}Assets".dependsOn unpackTask
-
-				variant.buildConfigField "String", "STORM_API_BASE", "\"${mergedStormConfig.apiBase}\""
-				variant.buildConfigField "String", "STORM_API_VERSION", "\"${mergedStormConfig.apiVersion}\""
-				variant.buildConfigField "String", "STORM_API_URL", "\"${mergedStormConfig.apiBase}/${mergedStormConfig.apiVersion}\""
-				variant.buildConfigField "String", "STORM_APP_ID", "\"${mergedStormConfig.appId}\""
-				variant.buildConfigField "String", "STORM_ORG_ID", "\"${mergedStormConfig.orgId}\""
-				variant.buildConfigField "String", "STORM_ORG_NAME", "\"${mergedStormConfig.orgName}\""
-				variant.buildConfigField "String", "STORM_APP_NAME", "\"${mergedStormConfig.orgName}-${mergedStormConfig.orgId}-${mergedStormConfig.appId}\""
-			} else {
+			if (!mergedStormConfig.isValid()) {
 				println "ERROR: Incomplete Storm configuration for \"${variant.name}\": ${mergedStormConfig}"
+				return
 			}
+
+			println "Storm configuration for \"${variant.name}\": ${mergedStormConfig}"
+
+			// Inject the Storm BuildConfig fields for this variant (requires buildFeatures { buildConfig true }).
+			variant.buildConfigFields.put("STORM_API_BASE", new BuildConfigField("String", "\"${mergedStormConfig.apiBase}\"".toString(), null))
+			variant.buildConfigFields.put("STORM_API_VERSION", new BuildConfigField("String", "\"${mergedStormConfig.apiVersion}\"".toString(), null))
+			variant.buildConfigFields.put("STORM_API_URL", new BuildConfigField("String", "\"${mergedStormConfig.apiBase}/${mergedStormConfig.apiVersion}\"".toString(), null))
+			variant.buildConfigFields.put("STORM_APP_ID", new BuildConfigField("String", "\"${mergedStormConfig.appId}\"".toString(), null))
+			variant.buildConfigFields.put("STORM_ORG_ID", new BuildConfigField("String", "\"${mergedStormConfig.orgId}\"".toString(), null))
+			variant.buildConfigFields.put("STORM_ORG_NAME", new BuildConfigField("String", "\"${mergedStormConfig.orgName}\"".toString(), null))
+			variant.buildConfigFields.put("STORM_APP_NAME", new BuildConfigField("String", "\"${mergedStormConfig.orgName}-${mergedStormConfig.orgId}-${mergedStormConfig.appId}\"".toString(), null))
+
+			// NEVER means this variant is not bundled with Storm content: emit no download / unpack / assets.
+			if (mergedStormConfig.bundleDownloadStrategy == BundleDownloadStrategy.NEVER) {
+				println "Skipping bundle download/unpack for \"${variant.name}\" as strategy is set to NEVER"
+				return
+			}
+
+			def strategy = mergedStormConfig.bundleDownloadStrategy
+			boolean requiresAuth = mergedStormConfig.requiresAuth()
+			String url = mergedStormConfig.url
+			String authUsername = mergedStormConfig.authUsername
+
+			String sanitisedUrl = url.replaceAll("[\\\\/:*?\"<>|]", "_")
+			def archiveFile = project.layout.buildDirectory.file("storm/${sanitisedUrl}/bundle.tar.gz")
+			String downloadTaskName = "stormDownload${sanitisedUrl.capitalize()}"
+
+			def downloadTask = project.tasks.names.contains(downloadTaskName)
+					? project.tasks.named(downloadTaskName)
+					: project.tasks.register(downloadTaskName, Download) {
+				if (requiresAuth) {
+					dependsOn authTask
+				}
+				/**
+				 * Only download if the flag to enable downloading on every assembly is explicitly requested
+				 */
+				onlyIf {
+					if (offline) {
+						println "Skipping bundle download in offline mode"
+						return false
+					}
+
+					// Always download if explicitly requested
+					if (explicitStormRequest) {
+						println "Explicitly requested download"
+						return true
+					}
+
+					switch (strategy) {
+						case BundleDownloadStrategy.ALWAYS:
+							println "Downloading bundle as strategy is set to ALWAYS"
+							return true
+						case BundleDownloadStrategy.IF_MISSING:
+							if (archiveFile.get().asFile.exists()) {
+								println "Skipping bundle download as cached archive exists on disk and strategy is IF_MISSING"
+								return false
+							} else {
+								println "Downloading initial bundle as no cached copy exists and strategy is IF_MISSING"
+								return true
+							}
+						case BundleDownloadStrategy.NEVER:
+							println "Skipping bundle download as strategy is set to NEVER"
+							return false
+					}
+
+					return false
+				}
+				doFirst { downloadTaskRef ->
+					println "Downloading from ${downloadTaskRef.src}..."
+					if (requiresAuth) {
+						println "Setting auth token for user ${authUsername}: ${authToken}"
+						downloadTaskRef.header "Authorization", authToken
+					}
+				}
+				src url
+				dest archiveFile.get().asFile
+				overwrite true
+			}
+
+			def unpackTask = project.tasks.register("stormUnpack${variant.name.capitalize()}Bundle", StormUnpackTask) {
+				dependsOn downloadTask
+				archive.set(archiveFile)
+				// The task is referenced via the explicit closure parameter (not the implicit delegate) so
+				// the predicate survives Gradle 9 configuration-cache serialization, which replaces a
+				// closure's owner/delegate with a "broken" placeholder.
+				onlyIf { unpackTaskRef ->
+					// Nothing to unpack if the bundle was never downloaded (e.g. offline with no cached copy).
+					if (!unpackTaskRef.archive.get().asFile.exists()) {
+						println "Skipping bundle unpack as no downloaded archive exists"
+						return false
+					}
+
+					// Always unpack if explicitly requested
+					if (explicitStormRequest) {
+						println "Explicitly requested unpack"
+						return true
+					}
+
+					switch (strategy) {
+						case BundleDownloadStrategy.ALWAYS:
+							println "Unpacking bundle as strategy is set to ALWAYS"
+							return true
+						case BundleDownloadStrategy.IF_MISSING:
+							if (new File(unpackTaskRef.outputDir.get().asFile, "manifest.json").exists()) {
+								println "Skipping bundle unpack as copy already exists in assets dir and strategy is IF_MISSING"
+								return false
+							} else {
+								println "Unpacking initial bundle as no copy exists in assets dir and strategy is IF_MISSING"
+								return true
+							}
+						case BundleDownloadStrategy.NEVER:
+							println "Skipping bundle unpack as strategy is set to NEVER"
+							return false
+					}
+
+					return false
+				}
+			}
+
+			// Hand the unpacked bundle to AGP as a generated assets source directory. AGP owns the output
+			// location and wires the unpack task into the asset-merging graph automatically.
+			variant.sources.assets?.addGeneratedSourceDirectory(unpackTask) { it.getOutputDir() }
 		}
 	}
 

--- a/plugin/src/main/groovy/com/cube/storm/content/StormUnpackTask.groovy
+++ b/plugin/src/main/groovy/com/cube/storm/content/StormUnpackTask.groovy
@@ -1,0 +1,60 @@
+package com.cube.storm.content
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ArchiveOperations
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+import javax.inject.Inject
+
+/**
+ * Untars a downloaded Storm bundle ({@code .tar.gz}) into a generated assets source directory.
+ *
+ * <p>The output directory is owned by the Android Gradle Plugin: it is wired in via
+ * {@code variant.sources.assets.addGeneratedSourceDirectory(...)}, which both sets the location and
+ * registers this task as a dependency of the variant's asset-merging step. That removes any need to
+ * hook internal AGP task names (which change between AGP versions).</p>
+ *
+ * <p>The task uses injected {@link ArchiveOperations} / {@link FileSystemOperations} services rather
+ * than the deprecated {@code Project} API at execution time, so it is compatible with Gradle 9.</p>
+ */
+abstract class StormUnpackTask extends DefaultTask {
+
+	/**
+	 * The downloaded bundle archive to unpack. Compression is inferred from the {@code .tar.gz}
+	 * extension.
+	 */
+	@InputFile
+	abstract RegularFileProperty getArchive()
+
+	/**
+	 * Destination assets directory. Set by AGP via {@code addGeneratedSourceDirectory}.
+	 */
+	@OutputDirectory
+	abstract DirectoryProperty getOutputDir()
+
+	@Inject
+	abstract ArchiveOperations getArchiveOperations()
+
+	@Inject
+	abstract FileSystemOperations getFileSystemOperations()
+
+	@TaskAction
+	void unpack() {
+		def destination = outputDir.get().asFile
+		def tar = archiveOperations.tarTree(archive.get().asFile)
+
+		// Start from a clean directory so removed bundle entries don't linger between builds.
+		fileSystemOperations.delete {
+			it.delete(destination)
+		}
+		fileSystemOperations.copy {
+			it.from(tar)
+			it.into(destination)
+		}
+	}
+}


### PR DESCRIPTION
## What?
- Migrates `content-gradle-plugin` from the legacy `android.applicationVariants` iterator (removed in AGP 9) to the stable `AndroidComponents.onVariants` API, so it works on AGP 7.2 → 9.x from one code path.
- Sets the `STORM_*` BuildConfig fields via `variant.buildConfigFields.put(...)` and hands the unpacked bundle to AGP as a generated assets source (`variant.sources.assets.addGeneratedSourceDirectory(...)`), removing the fragile hook on internal `generate<Variant>Assets` task names.
- Adds a typed, config-cache-safe `StormUnpackTask` (injected Archive/FileSystem operations, no execution-time `Project` access).
- Compiles against `com.android.tools.build:gradle-api` (compileOnly), bumps the plugin to `2.0.0`, and updates the example app to consume it (also moves the misplaced `buildFeatures { buildConfig }` to the `android` block).

## Why?
_No ticket — freeform request._

Unblocks moving consumer apps to AGP 9 / Gradle 9 (e.g. `brc-babychild-android-client`, OU23-428) — the plugin currently throws `Could not get unknown property 'applicationVariants'` under AGP 9, and no AGP-9-compatible release existed.

## Screenshots / Screen Recordings
Help the reviewer see what you have done.

## Accessibility
No accessibility changes in this PR.

## Testing

No automated tests added — manual testing steps below:

Verified locally against a throwaway `com.android.application` consumer applying the built plugin on AGP 8.13 / Gradle 8.13 (the `onVariants` API is identical on AGP 8 and 9):

- Plugin configures with no `applicationVariants` error; `storm` config merges correctly per variant; `stormUnpack<Variant>Bundle` + `stormDownload…` tasks register.
- `generateDebugBuildConfig` emits all seven `STORM_*` fields with correct values/quoting.
- End-to-end: live bundle downloaded, untarred by `StormUnpackTask`, and content flowed into `mergeDebugAssets`.
- Configuration cache: entry stores and reuses cleanly (IF_MISSING cache-hit skips tasks correctly) — confirms Gradle 9 readiness.

Still to do before merge (needs credentials/repo not available in this environment):
- Publish `2.0.0` to CodeArtifact.
- Verify against `brc-babychild-android-client` `feature/OU23-428-agp9-gradle9-kotlin2` (AGP 9.2.1 / Gradle 9.6.1): bump the classpath to `2.0.0` and run `./gradlew clean assembleStagingStormDebug`.

## Anything Else?
Breaking change: `2.0.0` requires AGP 7.2+; older-AGP consumers stay on the `1.0.x` line. Bundle content now unpacks into an AGP-managed build dir rather than `src/<variant>/assets`, so `clean` forces a re-fetch under `IF_MISSING`.
