### PR TITLE
:HIGH: feature/ARCBLOOD-4352 support CDN authorization via content key and bypass key [MEDIUM]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.iml
 local.properties
 build
+.DS_Store
+**/.DS_Store
 # Created by https://www.gitignore.io
 
 ### Android ###

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:8.13.0'
+		classpath 'com.android.tools.build:gradle:8.13.2'
 
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=3.0.0
+VERSION_NAME=3.0.1-rc1
 GROUP=com.3sidedcube.storm
 
 POM_NAME=LightningContent

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=3.0.1-rc1
+VERSION_NAME=3.0.1-rc2
 GROUP=com.3sidedcube.storm
 
 POM_NAME=LightningContent

--- a/library/src/main/java/com/cube/storm/ContentSettings.java
+++ b/library/src/main/java/com/cube/storm/ContentSettings.java
@@ -179,6 +179,11 @@ public class ContentSettings
 	@Getter @Setter private String authorizationToken;
 
 	/**
+	 * Content key to use when downloading updates/bundles from the CDN
+	 */
+	@Getter @Setter @Nullable private String contentKey;
+
+	/**
 	 * The builder class for {@link com.cube.storm.ContentSettings}. Use this to create a new {@link com.cube.storm.ContentSettings} instance
 	 * with the customised properties specific for your project.
 	 * <p/>
@@ -321,6 +326,19 @@ public class ContentSettings
 		public Builder authorizationToken(@NonNull String token)
 		{
 			construct.authorizationToken = token;
+			return this;
+		}
+
+		/**
+		 * Set the content key header to be used when downloading updates/bundles from the CDN
+		 *
+		 * @param contentKey The content key
+		 *
+		 * @return The {@link com.cube.storm.ContentSettings.Builder} instance for chaining
+		 */
+		public Builder contentKey(@Nullable String contentKey)
+		{
+			construct.contentKey = contentKey;
 			return this;
 		}
 

--- a/library/src/main/java/com/cube/storm/content/lib/manager/DefaultUpdateManager.java
+++ b/library/src/main/java/com/cube/storm/content/lib/manager/DefaultUpdateManager.java
@@ -251,6 +251,12 @@ public class DefaultUpdateManager implements UpdateManager
 						.get()
 						.header("Connection", "close");
 
+				String contentKey = ContentSettings.getInstance().getContentKey();
+				if (!TextUtils.isEmpty(contentKey))
+				{
+					request.header("x-content-key", contentKey);
+				}
+
 				// Get the response
 				Call call = redirectingHttpClient.newCall(request.build());
 				call.enqueue(new GZIPTarCacheConnectionInfoCallback(ContentSettings.getInstance().getStoragePath() + "/delta")

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -28,8 +28,8 @@ dependencies {
 POM_NAME='LightningContentGradlePlugin'
 POM_ARTIFACT_ID='content-gradle-plugin'
 POM_PACKAGING='jar'
-// 2.0.0: migrated to the AndroidComponents variant API. Requires AGP 7.2+ (supports AGP 9.x).
-VERSION_NAME="2.0.0"
+// 2.0.1: adds StormExtension.bypassKey, sent as the x-bypass-key header on the build-time bundle download request.
+VERSION_NAME="2.0.1-rc2"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/plugin/src/main/groovy/com/cube/storm/content/StormExtension.groovy
+++ b/plugin/src/main/groovy/com/cube/storm/content/StormExtension.groovy
@@ -9,6 +9,11 @@ class StormExtension {
     String bundleEnvironment = ""
     String authUsername = ""
     String authPassword = ""
+    /**
+     * Static key sent as the x-bypass-key header on the build-time bundle download request, for
+     * CDN edge gating that isn't tied to a running app (so Firebase AppCheck doesn't apply here).
+     */
+    String bypassKey = ""
     Date bundleTimestamp = null
     Boolean obeyLandmark = null
 
@@ -48,7 +53,8 @@ class StormExtension {
                 obeyLandmark: this.obeyLandmark == null ? other.obeyLandmark : this.obeyLandmark,
                 bundleDownloadStrategy: this.bundleDownloadStrategy == null ? other.bundleDownloadStrategy : this.bundleDownloadStrategy,
                 authUsername: this.authUsername.isEmpty() ? other.authUsername : this.authUsername,
-                authPassword: this.authPassword.isEmpty() ? other.authPassword : this.authPassword
+                authPassword: this.authPassword.isEmpty() ? other.authPassword : this.authPassword,
+                bypassKey: this.bypassKey.isEmpty() ? other.bypassKey : this.bypassKey
         )
     }
 
@@ -58,6 +64,6 @@ class StormExtension {
 
     public String toString()
     {
-        return "Storm(apiBase=${apiBase}, apiVersion=${apiVersion}, appId=${appId}, orgId=${orgId}, orgName=${orgName}, bundleEnv=${bundleEnvironment}, bundleTimestamp=${bundleTimestamp}, obeyLandmark=${obeyLandmark}, bundleDownloadStrategy=${bundleDownloadStrategy}, authUsername=${authUsername}, authPassword=${authPassword}, url=${url})"
+        return "Storm(apiBase=${apiBase}, apiVersion=${apiVersion}, appId=${appId}, orgId=${orgId}, orgName=${orgName}, bundleEnv=${bundleEnvironment}, bundleTimestamp=${bundleTimestamp}, obeyLandmark=${obeyLandmark}, bundleDownloadStrategy=${bundleDownloadStrategy}, authUsername=${authUsername}, authPassword=${authPassword}, bypassKey=${bypassKey.isEmpty() ? "" : "***"}, url=${url})"
     }
 }

--- a/plugin/src/main/groovy/com/cube/storm/content/StormPlugin.groovy
+++ b/plugin/src/main/groovy/com/cube/storm/content/StormPlugin.groovy
@@ -122,6 +122,7 @@ class StormPlugin implements Plugin<Project> {
 			boolean requiresAuth = mergedStormConfig.requiresAuth()
 			String url = mergedStormConfig.url
 			String authUsername = mergedStormConfig.authUsername
+			String bypassKey = mergedStormConfig.bypassKey
 
 			String sanitisedUrl = url.replaceAll("[\\\\/:*?\"<>|]", "_")
 			def archiveFile = project.layout.buildDirectory.file("storm/${sanitisedUrl}/bundle.tar.gz")
@@ -172,6 +173,9 @@ class StormPlugin implements Plugin<Project> {
 					if (requiresAuth) {
 						println "Setting auth token for user ${authUsername}: ${authToken}"
 						downloadTaskRef.header "Authorization", authToken
+					}
+					if (!bypassKey.isEmpty()) {
+						downloadTaskRef.header "x-bypass-key", bypassKey
 					}
 				}
 				src url


### PR DESCRIPTION
## What?

The CDN in front of Storm content bundles now requires either an `x-content-key` or `x-bypass-key` header on every request.

- `ContentSettings` gains an optional, mutable `contentKey` field (mirrors how apiBase/apiVersion are injected from the host app), which `DefaultUpdateManager` attaches as `x-content-key` on the runtime bundle/update download request.
- `StormExtension` gains an optional `bypassKey` field, which StormPlugin attaches as `x-bypass-key` on the build-time stormDownload.


## Why?

- https://3sidedcube.atlassian.net/browse/ARCBLOOD-4352


## Screenshots / Screen Recordings

-

## Accessibility

-


## Testing

-


## Anything Else?

- See the blood repo update in this PR: https://github.com/3sidedcube/arc-blood-android-client/pull/402
